### PR TITLE
Support for Modbus functions (0x04), (0x06) and (0x10)

### DIFF
--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -905,7 +905,10 @@ If IPv6 succeeds, both IPv4 and IPv6 might actually be active depending on the o
 If yes and a remote changes its IP-address, RRR must restart before the new address can be accepted. Default is no. 
 .El
 .SS modbus (PA)
-This module implements a modbus client capable of getting coil status from a remote modbus server.
+This module implements a modbus client supporting the functions
+.B Read Coils (0x01), Read Discrete Inputs (0x02), Read Holding Registers (0x03), Read Input Registers (0x04), Write Single Register (0x06)
+and
+.B Write Multiple Registers (0x10)
 .PP
 The module is controlled using array command messages from sender instances, and there are no configuration parameters.
 .PP
@@ -935,7 +938,7 @@ is used.
 If given, any messages generated as a result of the command will have this topic set.
 .It modbus_function_code
 The modbus command to send, the commands
-.B 0x01 Read Coils, 0x02 Read Discrete Inputs, 0x03 Read Holding Registers
+.B Read Coils (0x01), Read Discrete Inputs (0x02), Read Holding Registers (0x03), Read Input Registers (0x04), Write Single Register (0x06), Write Multiple Registers (0x10)
 are supported. If not given,
 .B 0x01
 is used.
@@ -943,7 +946,24 @@ The function code must be stored in the array field in decimal form.
 .It modbus_starting_address
 The starting address for applicable commands. Defaults to 0, and must be in the range 0 - 65535.
 .It modbus_quantity
-The quantity (e.g. number of coils or registers) to use. Defaults to 8  and must be in the range 1 - 2000 for coil functions, and defaults to 1 and must be in the range 1 - 125 for register functions.
+For
+.B Read Coils (0x01), Read Discrete Inputs (0x02)
+quantity defaults to 8 and must be in the range 1 - 2000.
+.br
+For
+.B Read Holding Registers (0x03), Read Input Registers (0x04)
+quantity defaults to 1 and must the in the range 1 - 125.
+.br
+For
+.B Write Multiple Registers (0x10)
+quantity defaults to 1 and must the in the range 1 - 123.
+.br
+For any other function code quantity is not required and will be ignored if present.
+.It modbus_contents
+The raw data to write in
+.B Write Single Register (0x06)
+and
+.B Write Multiple Registers (0x10).
 .It modbus_interval_ms
 If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed.
 .El
@@ -958,23 +978,46 @@ and they correspond to fields given in the protocol standard.
 .It Error
 .LI
 .B modbus_server, modbus_port, modbus_function_code, modbus_exception_code
-.It Read Coils (0x01), Read Discrete Inputs (0x02), Read Holding Registers (0x03)
+.It Read Coils (0x01), Read Discrete Inputs (0x02)
 .LI
 .B modbus_server, modbus_port, modbus_function_code, modbus_bytes, modbus_status
+.It Read Holding Registers (0x03), Read Input Registers (0x04)
+.LI
+.B modbus_server, modbus_port, modbus_function_code, modbus_bytes, modbus_contents
+.It Write Single Register (0x06)
+.LI
+.B modbus_server, modbus_port, modbus_function_code, modbus_starting_address, modbus_contents
+.It Write Multiple Registers (0x10)
+.LI
+.B modbus_server, modbus_port, modbus_function_code, modbus_starting_address
 .El
 .PP
 The array fields have the following contents:
 .PP
 .Bl -tag -width -indent
 .It modbus_function_code
-A one byte unsigned integer indicating a function code
+A one byte unsigned integer indicating a function code.
 .It modbus_exception_code
-A one byte unsigned integer indicating an exception code
+A one byte unsigned integer indicating an exception code.
 .It modbus_bytes
-A one byte unsigned integer indicating the size of a data field
+A one byte unsigned integer indicating the size of a data field.
 .It modbus_status
-A blob containing response data of a length indicated by
-.B modbus_bytes
+A blob containing response data from a 
+.B Read Coils (0x01) 
+or 
+.B Read Discrete Inputs (0x02) 
+response of a length indicated by
+.B modbus_bytes.
+.It modbus_contents
+For 
+.B Read Holding Registers (0x03), Read Input Registers (0x04)
+a blob containing response data from of a length indicated by
+.B modbus_bytes.
+.br
+For 
+.B Write Single Register (0x06)
+a blob containing response data of length 2.
+.B 
 .El
 .PP
 .SS python3 (PAI)

--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -1008,6 +1008,12 @@ or
 .B Read Discrete Inputs (0x02) 
 response of a length indicated by
 .B modbus_bytes.
+.It modbus_starting_address
+An unsigned integer containing the starting address field returned in a response from a
+.B  Write Single Register (0x06)
+or
+.B Write Multiple Registers (0x10)
+response.
 .It modbus_contents
 For 
 .B Read Holding Registers (0x03), Read Input Registers (0x04)

--- a/src/lib/modbus/rrr_modbus.c
+++ b/src/lib/modbus/rrr_modbus.c
@@ -285,7 +285,7 @@ static int __rrr_modbus_client_receive_starting_address_and_register_value (
 	return callback (
 			function_code,
 			transaction->transaction_id,
-			pdu->starting_address,
+			rrr_be16toh(pdu->starting_address),
 			pdu->contents,
 			transaction->transaction_private_data,
 			client->callbacks.arg
@@ -313,8 +313,8 @@ static int __rrr_modbus_client_receive_starting_address_and_quantity (
 	return callback (
 			function_code,
 			transaction->transaction_id,
-			pdu->starting_address,
-			pdu->quantity_of_registers,
+			rrr_be16toh(pdu->starting_address),
+			rrr_be16toh(pdu->quantity_of_registers),
 			transaction->transaction_private_data,
 			client->callbacks.arg
 	);
@@ -400,7 +400,7 @@ static int __rrr_modbus_client_receive_06_write_single_register (
 			transaction,
 			pdu,
 			pdu_size,
-			client->callbacks.cb_res_06_write_single_regsister
+			client->callbacks.cb_res_06_write_single_register
 	);
 }
 
@@ -416,7 +416,7 @@ static int __rrr_modbus_client_receive_16_write_multiple_registers (
 			transaction,
 			pdu,
 			pdu_size,
-			client->callbacks.cb_res_16_write_multiple_regsisters
+			client->callbacks.cb_res_16_write_multiple_registers
 	);
 }
 

--- a/src/lib/modbus/rrr_modbus.h
+++ b/src/lib/modbus/rrr_modbus.h
@@ -34,11 +34,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RRR_MODBUS_DONE        RRR_READ_EOF
 #define RRR_MODBUS_INCOMPLETE  RRR_READ_INCOMPLETE
 
-#define RRR_MODBUS_FUNCTION_CODE_01_READ_COILS               0x01
-#define RRR_MODBUS_FUNCTION_CODE_02_READ_DISCRETE_INPUTS     0x02
-#define RRR_MODBUS_FUNCTION_CODE_03_READ_HOLDING_REGISTERS   0x03
-#define RRR_MODBUS_FUNCTION_CODE_04_READ_INPUT_REGISTERS     0x04
-#define RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTER  0x10
+#define RRR_MODBUS_FUNCTION_CODE_01_READ_COILS                 0x01
+#define RRR_MODBUS_FUNCTION_CODE_02_READ_DISCRETE_INPUTS       0x02
+#define RRR_MODBUS_FUNCTION_CODE_03_READ_HOLDING_REGISTERS     0x03
+#define RRR_MODBUS_FUNCTION_CODE_04_READ_INPUT_REGISTERS       0x04
+#define RRR_MODBUS_FUNCTION_CODE_06_WRITE_SINGLE_REGISTER      0x06
+#define RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTERS   0x10
 
 #define RRR_MODBUS_ERROR_CALLBACK_ARGS \
     uint16_t transaction_id, uint8_t function_code, uint8_t error_code, void *transaction_private_data, void *arg
@@ -48,6 +49,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS \
     uint8_t function_code, uint16_t transaction_id, uint8_t byte_count, const uint8_t *register_value, void *transaction_private_data, void *arg
+
+#define RRR_MODBUS_STARTING_ADDRESS_AND_REGISTER_VALUE_CALLBACK_ARGS \
+    uint8_t function_code, uint16_t transaction_id, uint16_t starting_address, const uint8_t *register_value, void *transaction_private_data, void *arg
 
 #define RRR_MODBUS_STARTING_ADDRESS_AND_QUANTITY_CALLBACK_ARGS \
     uint8_t function_code, uint16_t transaction_id, uint16_t starting_address, uint16_t quantity, void *transaction_private_data, void *arg
@@ -60,6 +64,7 @@ struct rrr_modbus_client_callbacks {
 	int  (*cb_res_02_read_discrete_inputs)(RRR_MODBUS_BYTE_COUNT_AND_COILS_CALLBACK_ARGS);
 	int  (*cb_res_03_read_holding_registers)(RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS);
 	int  (*cb_res_04_read_input_registers)(RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS);
+	int  (*cb_res_06_write_single_regsister)(RRR_MODBUS_STARTING_ADDRESS_AND_REGISTER_VALUE_CALLBACK_ARGS);
 	int  (*cb_res_16_write_multiple_regsisters)(RRR_MODBUS_STARTING_ADDRESS_AND_QUANTITY_CALLBACK_ARGS);
 	void  *arg;
 };
@@ -108,6 +113,12 @@ int rrr_modbus_client_req_04_read_input_registers (
 		struct rrr_modbus_client *client,
 		uint16_t starting_address,
 		uint16_t quantity_of_registers,
+		void *private_data_arg
+);
+int rrr_modbus_client_req_06_write_single_register (
+		struct rrr_modbus_client *client,
+		uint16_t starting_address,
+		uint8_t *contents,
 		void *private_data_arg
 );
 int rrr_modbus_client_req_16_write_multiple_registers (

--- a/src/lib/modbus/rrr_modbus.h
+++ b/src/lib/modbus/rrr_modbus.h
@@ -50,6 +50,7 @@ struct rrr_modbus_client_callbacks {
 	int  (*cb_res_01_read_coils)(RRR_MODBUS_BYTE_COUNT_AND_COILS_CALLBACK_ARGS);
 	int  (*cb_res_02_read_discrete_inputs)(RRR_MODBUS_BYTE_COUNT_AND_COILS_CALLBACK_ARGS);
 	int  (*cb_res_03_read_holding_registers)(RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS);
+	int  (*cb_res_04_read_input_registers)(RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS);
 	void  *arg;
 };
 
@@ -88,6 +89,12 @@ int rrr_modbus_client_req_02_read_discrete_inputs (
 		void *private_data_arg
 );
 int rrr_modbus_client_req_03_read_holding_registers (
+		struct rrr_modbus_client *client,
+		uint16_t starting_address,
+		uint16_t quantity_of_registers,
+		void *private_data_arg
+);
+int rrr_modbus_client_req_04_read_input_registers (
 		struct rrr_modbus_client *client,
 		uint16_t starting_address,
 		uint16_t quantity_of_registers,

--- a/src/lib/modbus/rrr_modbus.h
+++ b/src/lib/modbus/rrr_modbus.h
@@ -34,6 +34,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RRR_MODBUS_DONE        RRR_READ_EOF
 #define RRR_MODBUS_INCOMPLETE  RRR_READ_INCOMPLETE
 
+#define RRR_MODBUS_FUNCTION_CODE_01_READ_COILS               0x01
+#define RRR_MODBUS_FUNCTION_CODE_02_READ_DISCRETE_INPUTS     0x02
+#define RRR_MODBUS_FUNCTION_CODE_03_READ_HOLDING_REGISTERS   0x03
+#define RRR_MODBUS_FUNCTION_CODE_04_READ_INPUT_REGISTERS     0x04
+#define RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTER  0x10
+
 #define RRR_MODBUS_ERROR_CALLBACK_ARGS \
     uint16_t transaction_id, uint8_t function_code, uint8_t error_code, void *transaction_private_data, void *arg
 
@@ -43,6 +49,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS \
     uint8_t function_code, uint16_t transaction_id, uint8_t byte_count, const uint8_t *register_value, void *transaction_private_data, void *arg
 
+#define RRR_MODBUS_STARTING_ADDRESS_AND_QUANTITY_CALLBACK_ARGS \
+    uint8_t function_code, uint16_t transaction_id, uint16_t starting_address, uint16_t quantity, void *transaction_private_data, void *arg
+
 struct rrr_modbus_client_callbacks {
 	int  (*cb_req_transaction_private_data_create)(void **result, void *private_data_arg, void *arg);
 	void (*cb_req_transaction_private_data_destroy)(void *transaction_private_data);
@@ -51,6 +60,7 @@ struct rrr_modbus_client_callbacks {
 	int  (*cb_res_02_read_discrete_inputs)(RRR_MODBUS_BYTE_COUNT_AND_COILS_CALLBACK_ARGS);
 	int  (*cb_res_03_read_holding_registers)(RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS);
 	int  (*cb_res_04_read_input_registers)(RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS);
+	int  (*cb_res_16_write_multiple_regsisters)(RRR_MODBUS_STARTING_ADDRESS_AND_QUANTITY_CALLBACK_ARGS);
 	void  *arg;
 };
 
@@ -100,6 +110,12 @@ int rrr_modbus_client_req_04_read_input_registers (
 		uint16_t quantity_of_registers,
 		void *private_data_arg
 );
-
+int rrr_modbus_client_req_16_write_multiple_registers (
+		struct rrr_modbus_client *client,
+		uint16_t starting_address,
+		uint16_t quantity_of_registers,
+		uint8_t *contents,
+		void *private_data_arg
+);
 #endif /* RRR_MODBUS_H */
 

--- a/src/lib/modbus/rrr_modbus.h
+++ b/src/lib/modbus/rrr_modbus.h
@@ -64,8 +64,8 @@ struct rrr_modbus_client_callbacks {
 	int  (*cb_res_02_read_discrete_inputs)(RRR_MODBUS_BYTE_COUNT_AND_COILS_CALLBACK_ARGS);
 	int  (*cb_res_03_read_holding_registers)(RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS);
 	int  (*cb_res_04_read_input_registers)(RRR_MODBUS_BYTE_COUNT_AND_REGISTERS_CALLBACK_ARGS);
-	int  (*cb_res_06_write_single_regsister)(RRR_MODBUS_STARTING_ADDRESS_AND_REGISTER_VALUE_CALLBACK_ARGS);
-	int  (*cb_res_16_write_multiple_regsisters)(RRR_MODBUS_STARTING_ADDRESS_AND_QUANTITY_CALLBACK_ARGS);
+	int  (*cb_res_06_write_single_register)(RRR_MODBUS_STARTING_ADDRESS_AND_REGISTER_VALUE_CALLBACK_ARGS);
+	int  (*cb_res_16_write_multiple_registers)(RRR_MODBUS_STARTING_ADDRESS_AND_QUANTITY_CALLBACK_ARGS);
 	void  *arg;
 };
 

--- a/src/modules/p_modbus.c
+++ b/src/modules/p_modbus.c
@@ -65,8 +65,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MODBUS_STARTING_ADDRESS_MAX 0xffff
 #define MODBUS_QUANTITY_COIL_MIN 1
 #define MODBUS_QUANTITY_COIL_MAX 2000
-#define MODBUS_QUANTITY_REGISTER_MIN 1
-#define MODBUS_QUANTITY_REGISTER_MAX 125
+#define MODBUS_QUANTITY_READ_REGISTER_MIN 1
+#define MODBUS_QUANTITY_READ_REGISTER_MAX 125
+#define MODBUS_QUANTITY_WRITE_REGISTER_MIN 1
+#define MODBUS_QUANTITY_WRITE_REGISTER_MAX 123
+#define MODBUS_CONTENTS_MAX (MODBUS_QUANTITY_WRITE_REGISTER_MAX * 2)
 
 static const char *modbus_field_server            = "modbus_server";
 static const char *modbus_field_port              = "modbus_port";
@@ -76,6 +79,7 @@ static const char *modbus_field_starting_address  = "modbus_starting_address";
 static const char *modbus_field_quantity          = "modbus_quantity";
 static const char *modbus_field_bytes             = "modbus_bytes";
 static const char *modbus_field_status            = "modbus_status";
+static const char *modbus_field_contents          = "modbus_contents";
 
 static const char *modbus_field_interval_ms       = "modbus_interval_ms";
 static const char *modbus_field_response_topic    = "modbus_response_topic";
@@ -90,6 +94,7 @@ struct modbus_command {
 	uint8_t function;
 	uint16_t starting_address;
 	uint16_t quantity;
+	uint8_t contents[MODBUS_CONTENTS_MAX];
 };
 
 struct modbus_command_node {
@@ -233,6 +238,8 @@ static int modbus_command_collection_push_or_replace (
 		uint8_t function,
 		uint16_t starting_address,
 		uint16_t quantity,
+		uint8_t *contents,
+		uint32_t contents_length,
 		uint64_t interval_ms,
 		char **response_topic
 ) {
@@ -251,11 +258,23 @@ static int modbus_command_collection_push_or_replace (
 		goto out;
 	}
 
+	if (contents_length > sizeof(command.contents))
+	{
+		RRR_MSG_0("Length of contents exceeds maximum in %s of modbus instance %s\n",
+			__func__, INSTANCE_D_NAME(data->thread_data));
+		ret = 1;
+		goto out;
+	}
+
 	strcpy(command.server, server);
 	command.port = port;
 	command.function = function;
 	command.starting_address = starting_address;
 	command.quantity = quantity;
+
+	if (contents != NULL && contents_length > 0) {
+		memcpy(command.contents, contents, contents_length);
+	}
 
 	RRR_LL_ITERATE_BEGIN(&data->commands, struct modbus_command_node);
 		if (memcmp(&node->command, &command, sizeof(command)) != 0) {
@@ -566,7 +585,57 @@ static int modbus_callback_res_byte_count_and_values (
 		goto push_fail;
 	}
 
-	if ((ret = rrr_array_push_value_blob_with_tag_with_size (&array, modbus_field_status, (const char *) coil_status, byte_count)) != 0) {
+	const char *response_data_tag = (function_code < 3) ? modbus_field_status : modbus_field_contents;
+
+	if ((ret = rrr_array_push_value_blob_with_tag_with_size (&array, response_data_tag, (const char *) coil_status, byte_count)) != 0) {
+		goto push_fail;
+	}
+
+	if ((ret = modbus_output (
+			client_data->data,
+			&array,
+			transaction_data->response_topic,
+			transaction_data->response_topic_length,
+			client_data->server,
+			client_data->port,
+			function_code
+	)) != 0) {
+		goto out;
+	}
+
+	goto out;
+	push_fail:
+		RRR_MSG_0("Failed to push array value in %s\n", __func__);
+	out:
+		rrr_array_clear(&array);
+		return ret;
+}
+
+static int modbus_callback_res_starting_address_and_quantity (
+		RRR_MODBUS_STARTING_ADDRESS_AND_QUANTITY_CALLBACK_ARGS
+) {
+	struct modbus_client_data *client_data = arg;
+	struct modbus_transaction_data *transaction_data = transaction_private_data;
+	struct modbus_data *data = client_data->data;
+
+	int ret = 0;
+
+	struct rrr_array array = {0};
+
+	RRR_DBG_2("Response from server %s:%u in modbus instance %s: Transaction %u function %u starting address %u quantity %u \n",
+		client_data->server,
+		client_data->port,
+		INSTANCE_D_NAME(data->thread_data),
+		transaction_id,
+		function_code,
+		starting_address,
+		quantity);
+
+	if ((ret = rrr_array_push_value_u64_with_tag (&array, modbus_field_starting_address, starting_address)) != 0) {
+		goto push_fail;
+	}
+
+	if ((ret = rrr_array_push_value_u64_with_tag (&array, modbus_field_quantity, quantity)) != 0) {
 		goto push_fail;
 	}
 
@@ -722,7 +791,7 @@ static int modbus_callback_data_prepare (
 	};
 
 	switch (command->function) {
-		case 0x01: // Read Coils
+		case RRR_MODBUS_FUNCTION_CODE_01_READ_COILS:
 			ret = rrr_modbus_client_req_01_read_coils (
 					client_data->client,
 					command->starting_address,
@@ -730,7 +799,7 @@ static int modbus_callback_data_prepare (
 					&private_data_create_callback_data
 			);
 			break;
-		case 0x02: // Read Discrete Inputs
+		case RRR_MODBUS_FUNCTION_CODE_02_READ_DISCRETE_INPUTS:
 			ret = rrr_modbus_client_req_02_read_discrete_inputs (
 					client_data->client,
 					command->starting_address,
@@ -738,7 +807,7 @@ static int modbus_callback_data_prepare (
 					&private_data_create_callback_data
 			);
 			break;
-		case 0x03: // Read Holding Registers
+		case RRR_MODBUS_FUNCTION_CODE_03_READ_HOLDING_REGISTERS:
 			ret = rrr_modbus_client_req_03_read_holding_registers (
 					client_data->client,
 					command->starting_address,
@@ -746,11 +815,20 @@ static int modbus_callback_data_prepare (
 					&private_data_create_callback_data
 			);
 			break;
-		case 0x04: // Read Input Registers
+		case RRR_MODBUS_FUNCTION_CODE_04_READ_INPUT_REGISTERS:
 			ret = rrr_modbus_client_req_04_read_input_registers (
 					client_data->client,
 					command->starting_address,
 					command->quantity,
+					&private_data_create_callback_data
+			);
+			break;
+		case RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTER:
+			ret = rrr_modbus_client_req_16_write_multiple_registers (
+					client_data->client,
+					command->starting_address,
+					command->quantity,
+					command->contents,
 					&private_data_create_callback_data
 			);
 			break;
@@ -952,6 +1030,8 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 	unsigned long long modbus_function = MODBUS_DEFAULT_FUNCTION;
 	unsigned long long modbus_quantity; // Default is set after we are sure about the function
 	unsigned long long modbus_starting_address = MODBUS_DEFAULT_STARTING_ADDRESS;
+	uint8_t *modbus_contents = NULL;
+	uint32_t modbus_contents_length = 0;
 	unsigned long long modbus_interval_ms = MODBUS_DEFAULT_INTERVAL_MS;
 	char *modbus_response_topic = MODBUS_DEFAULT_RESPONSE_TOPIC;
 
@@ -989,6 +1069,26 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 	GET_VALUE_ULL(interval_ms);
 	GET_VALUE_STR(response_topic);
 
+	if (modbus_function == RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTER) {
+		const struct rrr_type_value *modbus_contents_value;
+		if((modbus_contents_value = rrr_array_value_get_by_tag_const(&array, modbus_field_contents)) == NULL) {
+			RRR_MSG_0("Warning: Failed to get value of field %s of command message to modbus instance %s\n", \
+				modbus_field_contents, INSTANCE_D_NAME(data->thread_data));
+			ret = 0;
+			goto drop;
+		}
+
+		if (!RRR_TYPE_IS_BLOB(modbus_contents_value->definition->type)) {
+			RRR_MSG_0("Invalid type for field 'modbus_contents' to modbus instance %s, only blob allowed. Dropping it.\n",
+				INSTANCE_D_NAME(data->thread_data));
+			ret = 0;
+		  goto drop;
+		}
+
+		modbus_contents = (uint8_t*)modbus_contents_value->data;
+		modbus_contents_length = modbus_contents_value->total_stored_length;
+	}
+
 	if (modbus_server != NULL && strlen(modbus_server) > MODBUS_SERVER_MAX - 1) {
 		RRR_MSG_0("Field 'modbus_server' exceeds maximum length in command message to modbus instance %s, dropping it.\n",
 			INSTANCE_D_NAME(data->thread_data));
@@ -1009,7 +1109,11 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 		}
 	}
 
-	if (modbus_function < 1 || modbus_function > 4) {
+	if (modbus_function != RRR_MODBUS_FUNCTION_CODE_01_READ_COILS &&
+	    modbus_function != RRR_MODBUS_FUNCTION_CODE_02_READ_DISCRETE_INPUTS &&
+	    modbus_function != RRR_MODBUS_FUNCTION_CODE_03_READ_HOLDING_REGISTERS &&
+	    modbus_function != RRR_MODBUS_FUNCTION_CODE_04_READ_INPUT_REGISTERS &&
+	    modbus_function != RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTER) {
 		RRR_MSG_0("Invalid value for field 'modbus_function' %" PRIu64 " to modbus instance %s, only a value between 1 and 3 is allowed. Dropping it.\n",
 			modbus_function, INSTANCE_D_NAME(data->thread_data));
 		goto drop;
@@ -1022,19 +1126,32 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 	}
 
 	switch (modbus_function) {
-		case 1:
-		case 2:
+		case RRR_MODBUS_FUNCTION_CODE_01_READ_COILS:
+		case RRR_MODBUS_FUNCTION_CODE_02_READ_DISCRETE_INPUTS:
 			if (modbus_quantity < MODBUS_QUANTITY_COIL_MIN || modbus_quantity > MODBUS_QUANTITY_COIL_MAX) {
 				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %u-%u for this function (%u) while %" PRIu64 " was given, dropping it.\n",
 					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_COIL_MIN, MODBUS_QUANTITY_COIL_MAX, modbus_function, modbus_quantity);
 				goto drop;
 			}
 			break;
-		case 3:
-		case 4:
-			if (modbus_quantity < MODBUS_QUANTITY_REGISTER_MIN || modbus_quantity > MODBUS_QUANTITY_REGISTER_MAX) {
+		case RRR_MODBUS_FUNCTION_CODE_03_READ_HOLDING_REGISTERS:
+		case RRR_MODBUS_FUNCTION_CODE_04_READ_INPUT_REGISTERS:
+			if (modbus_quantity < MODBUS_QUANTITY_READ_REGISTER_MIN || modbus_quantity > MODBUS_QUANTITY_READ_REGISTER_MAX) {
 				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %u-%u for this function (%u) while %" PRIu64 " was given, dropping it.\n",
-					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_REGISTER_MIN, MODBUS_QUANTITY_REGISTER_MAX, modbus_function, modbus_quantity);
+					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_READ_REGISTER_MIN, MODBUS_QUANTITY_READ_REGISTER_MAX, modbus_function, modbus_quantity);
+				goto drop;
+			}
+			break;
+		case RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTER:
+			if (modbus_quantity < MODBUS_QUANTITY_WRITE_REGISTER_MIN || modbus_quantity > MODBUS_QUANTITY_WRITE_REGISTER_MAX) {
+				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %u-%u for this function (%u) while %" PRIu64 " was given, dropping it.\n",
+					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_WRITE_REGISTER_MIN, MODBUS_QUANTITY_WRITE_REGISTER_MAX, modbus_function, modbus_quantity);
+				goto drop;
+			}
+
+			if (modbus_contents_length != modbus_quantity * 2) {
+				RRR_MSG_0("Invalid size for field 'modbus_content' to modbus instance %s. Size should be 'modbus_quantity'*2 (%u) while %" PRIu32 " was given, dropping it.\n",
+					INSTANCE_D_NAME(data->thread_data), modbus_quantity*2u, modbus_contents_length);
 				goto drop;
 			}
 			break;
@@ -1051,6 +1168,8 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 			(uint8_t) modbus_function,
 			(uint16_t) modbus_starting_address,
 			(uint16_t) modbus_quantity,
+			modbus_contents,
+			modbus_contents_length,
 			(uint64_t) modbus_interval_ms,
 			&modbus_response_topic /* Memory is consumed upon success */
 	)) != 0) {
@@ -1189,6 +1308,7 @@ static void *thread_entry_modbus (struct rrr_thread *thread) {
 	data->modbus_client_callbacks.cb_res_02_read_discrete_inputs = modbus_callback_res_byte_count_and_values;
 	data->modbus_client_callbacks.cb_res_03_read_holding_registers = modbus_callback_res_byte_count_and_values;
 	data->modbus_client_callbacks.cb_res_04_read_input_registers = modbus_callback_res_byte_count_and_values;
+	data->modbus_client_callbacks.cb_res_16_write_multiple_regsisters = modbus_callback_res_starting_address_and_quantity;
 	data->modbus_client_callbacks.cb_res_error = modbus_callback_res_error;
 
 	if (rrr_socket_client_collection_new (&data->collection_tcp, INSTANCE_D_EVENTS(thread_data), INSTANCE_D_NAME(data->thread_data)) != 0) {

--- a/src/modules/p_modbus.c
+++ b/src/modules/p_modbus.c
@@ -1016,14 +1016,14 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 	switch (modbus_function) {
 		case 1:
 		case 2:
-			if (MODBUS_QUANTITY_COIL_MIN < 1 || modbus_quantity > MODBUS_QUANTITY_COIL_MAX) {
+			if (modbus_quantity < MODBUS_QUANTITY_COIL_MIN || modbus_quantity > MODBUS_QUANTITY_COIL_MAX) {
 				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %u-%u for this function (%u) while %" PRIu64 " was given, dropping it.\n",
 					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_COIL_MIN, MODBUS_QUANTITY_COIL_MAX, modbus_function, modbus_quantity);
 				goto drop;
 			}
 			break;
 		case 3:
-			if (MODBUS_QUANTITY_REGISTER_MIN < 1 || modbus_quantity > MODBUS_QUANTITY_REGISTER_MAX) {
+			if (modbus_quantity < MODBUS_QUANTITY_REGISTER_MIN || modbus_quantity > MODBUS_QUANTITY_REGISTER_MAX) {
 				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %u-%u for this function (%u) while %" PRIu64 " was given, dropping it.\n",
 					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_REGISTER_MIN, MODBUS_QUANTITY_REGISTER_MAX, modbus_function, modbus_quantity);
 				goto drop;

--- a/src/modules/p_modbus.c
+++ b/src/modules/p_modbus.c
@@ -1393,8 +1393,8 @@ static void *thread_entry_modbus (struct rrr_thread *thread) {
 	data->modbus_client_callbacks.cb_res_02_read_discrete_inputs = modbus_callback_res_byte_count_and_values;
 	data->modbus_client_callbacks.cb_res_03_read_holding_registers = modbus_callback_res_byte_count_and_values;
 	data->modbus_client_callbacks.cb_res_04_read_input_registers = modbus_callback_res_byte_count_and_values;
-	data->modbus_client_callbacks.cb_res_06_write_single_regsister = modbus_callback_res_starting_address_and_register_value;
-	data->modbus_client_callbacks.cb_res_16_write_multiple_regsisters = modbus_callback_res_starting_address_and_quantity;
+	data->modbus_client_callbacks.cb_res_06_write_single_register = modbus_callback_res_starting_address_and_register_value;
+	data->modbus_client_callbacks.cb_res_16_write_multiple_registers = modbus_callback_res_starting_address_and_quantity;
 	data->modbus_client_callbacks.cb_res_error = modbus_callback_res_error;
 
 	if (rrr_socket_client_collection_new (&data->collection_tcp, INSTANCE_D_EVENTS(thread_data), INSTANCE_D_NAME(data->thread_data)) != 0) {


### PR DESCRIPTION
The following changes has been made:

- Added support for (0x04) "Read Input Registers", 
- Added support for (0x06) "Write Single Register" 
- Added support for (0x10) "Write Multiple Registers
- Added tests for the new Modbus functions
- Updated man pages for Modbus section
