### PR TITLE
Added support for "oneshot" modbus requests

### DIFF
--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -979,11 +979,21 @@ commands are only sent at the given intervals.
 
 Whenever a new interval is set or and old interval is changed, no command will be sent to the modbus device before this interval has passed.
 .It modbus_oneshot_timeout_ms
-If given, the command will only be sent once with the specified timeout. If the timeout occurs a response will be generated with the array field
-.B modbus_error
-present. Must be equal or greater than 0. May not be given if
+If given, the command will only be sent once with the specified timeout.
+Must be than 0. May not be given if
 .B modbus_interval_ms
 is given.
+.PP
+When the message has been queued for sending after a connection is established, or when a send timeout occurs, a status message is generated
+containing the following fields:
+.Bl -tag -width -indent
+.It modbus_oneshot_status
+Set to either
+.B timeout
+or
+.B queued
+indicating that the given command has been queued for sending to the modbus device or that the given timeout was exceeded.
+.El
 
 When using this parameter, it is guaranteed that exactly one command is sent to the modbus device (or attempt is made)
 for each received command message and that one response message is generated either with and error message set or

--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -918,9 +918,6 @@ and
 .B modbus_interval_ms
 controls wether or not a command is to be repeated or sent only once.
 .PP
-The interval for a command may be changed by passing a command message with all other parameters being equal as another active command.
-After a command has been received, it is repeated for at most two seconds at the given interval.
-.PP
 If different commands are used on the same server, they will share connection.
 .PP
 Please refer to the
@@ -973,12 +970,24 @@ If given, the command is repeated at the given interval for two seconds. Default
 be given if
 .B modbus_oneshot_timeout_ms
 is given.
+The interval for a command may be changed by passing a command message with all other parameters being equal as another active command.
+After a command has been received, it is repeated for at most two seconds at the given interval.
+
+For continuous operation, a new message with the same interval must be sent before the timeout is encountered.
+Sending multiple (equal) command messages repeatedly does not cause extra commands being passed to the modbus device,
+commands are only sent at the given intervals.
+
+Whenever a new interval is set or and old interval is changed, no command will be sent to the modbus device before this interval has passed.
 .It modbus_oneshot_timeout_ms
 If given, the command will only be sent once with the specified timeout. If the timeout occurs a response will be generated with the array field
 .B modbus_error
 present. Must be equal or greater than 0. May not be given if
 .B modbus_interval_ms
 is given.
+
+When using this parameter, it is guaranteed that exactly one command is sent to the modbus device (or attempt is made)
+for each received command message and that one response message is generated either with and error message set or
+containing modbus response data.
 .El
 .PP
 The following response messages and array fields are generated as a result of the modbus server

--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -979,11 +979,10 @@ commands are only sent at the given intervals.
 
 Whenever a new interval is set or and old interval is changed, no command will be sent to the modbus device before this interval has passed.
 .It modbus_oneshot_timeout_ms
-If given, the command will only be sent once with the specified timeout.
-Must be than 0. May not be given if
+If given, the command will only be sent once with the specified timeout. Must be greater than 0. May not be given if
 .B modbus_interval_ms
 is given.
-.PP
+
 When the message has been queued for sending after a connection is established, or when a send timeout occurs, a status message is generated
 containing the following fields:
 .Bl -tag -width -indent
@@ -1056,14 +1055,6 @@ For
 .B Write Single Register (0x06)
 a blob containing response data of length 2.
 .B
-.It modbus_error
-A string containing the reason for an internal RRR modbus error. Is either not set or has one of the following values:
-.Bl -tag -width -indent
-.It oneshot_timeout
-Indicates that the timeout for a one-shot request set in
-.B modbus_oneshot_timeout_ms
-was reached and that no response was received.
-.El
 .PP
 .SS python3 (PAI)
 This module can send messages to a custom python program and read them back.

--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -175,7 +175,7 @@ sep1#separator
 	# Push two topic filters to the stack
 	T my_topic_a/+
 	T my_topic_b/+
-	# Run OR operator on the two stack values, leaves a boolean value on the stack
+	# Run OR operator on the two stack values, leaves a boolean value on the stack 
 	OR
 	# Set the reader instance_receier_1 to receive messages matching one of the filters
 	D instance_receiver_1
@@ -214,7 +214,7 @@ sep1#separator
 	# Push two topic filters to the stack
 	T my_topic_a/+
 	T my_topic_b/+
-	# Run OR operator on the two stack values, leaves a boolean value on the stack
+	# Run OR operator on the two stack values, leaves a boolean value on the stack 
 	OR
 	# Push a method name to the stack and apply the name. Bail out if a method was set.
 	M method_topic
@@ -253,7 +253,7 @@ types to be specified in their configuration. If the total size of the input doe
 of the message will fail. Some modules also generate array messages internally, and they can be created within Perl and
 Python scripts. Fields from an HTTP request can be mapped into an array, and an array can be mapped into database columns.
 .PP
-The general syntax for an array parsing specification (without branches) is a comma separated list of types with length and item count specifications.
+The general syntax for an array parsing specification (without branches) is a comma separated list of types with length and item count specifications. 
 .PP
 .Dl type1[length1][@count1][#tag1][,type2[length2][@count2][#tag2]][,...]
 .PP
@@ -289,7 +289,7 @@ section of
 for the complete specification of all the types, and the specification for array trees (branching with IF-blocks).
 .SS IP MESSAGES
 Some messages contain IP data, for instance messages created by a module which reads from the network. The address
-of the sender will be contained within the message. All modules may use IP-messages, but not all of them use the IP-data.
+of the sender will be contained within the message. All modules may use IP-messages, but not all of them use the IP-data. 
 .SH BUFFERS
 .PP
 Each instance of a source or processor module has an output buffer from which other modules read. If buffer is
@@ -436,12 +436,12 @@ Module supports data arrays
 Module supports IP messages
 .El
 .PP
-All modules support array and/or IP-messages, also those who do not have
+All modules support array and/or IP-messages, also those who do not have  
 .B A
 or
 .B I
 specified. Array- and IP-capable modules may however use or modify data from such messages.
-Messages may have both IP- and Array-data simultaneously.
+Messages may have both IP- and Array-data simultaneously. 
 .PP
 The following modules are available, they are discussed in detail further down.
 .PP
@@ -456,10 +456,10 @@ Dumps messages, used for debugging and performance measurements.
 Handles IP communication, UDP and TCP.
 
 .It exploder (PA)
-Splits RRR array messages into multiple messages.
+Splits RRR array messages into multiple messages. 
 
 .It mangler (PA)
-Converts between data types in RRR arrays.
+Converts between data types in RRR arrays. 
 
 .It buffer (P)
 Buffers messages, may be used to duplicate messages to multiple readers.
@@ -605,7 +605,7 @@ If left unspecified, no listening takes place.
 .It ip_input_types=ARRAY DEFINITION
 Specification of expected data to receive from remote. See
 .Xr rrr_post(1)
-for the syntax.
+for the syntax. 
 To receive RRR messages, set the definition to
 .B msg
 and set
@@ -618,7 +618,7 @@ Array data on UDP will only be read if an UDP listening port is set.
 .It ip_strip_array_separators={yes|no}
 If set to yes, any array fields of the
 .B sep
-type is stripped out before RRR array messages are created. Defaults to no.
+type is stripped out before RRR array messages are created. Defaults to no.  
 
 .It ip_extract_rrr_messages={yes|no}
 Extract any RRR messages from the received data (if specified in ip_input_types) and save them in the buffer for other modules to pick up.
@@ -682,7 +682,7 @@ Default is no timeout (same as 0).
 .It ip_smart_timeout={yes|no}
 If set to yes and a message is successfully sent, reset the timeout counter for all other unsent messages destined for the same host, port and protocol currently in the queue.
 If set to no, unsent messages will time out according to the current send timeout regardless of whether other messages to the same destination have been sent or not in the meantime.
-Defaults to no.
+Defaults to no. 
 
 .It ip_timeout_action={retry|drop|return}
 What do do when a message times out after being undeliverable. In case of
@@ -696,7 +696,7 @@ the destination address if the target host is unreachable, and possibly log erro
 .B retry
 is used, then
 .B ip_send_timeout
-must be set to zero or left undefined.
+must be set to zero or left undefined. 
 
 .It ip_graylist_timeout_ms=MILLISECONDS
 If a TCP destination is unreachable, add it to the graylist and retry only after the specified  number of milliseconds has passed.
@@ -712,8 +712,8 @@ The TTL check is not the same as the send timeout, it does not respect
 nor
 .B ip_smart_timeout.
 TTL expiration also applies to partially sent messages.
-Defaults to 0 which means that TTL check is disabled.
-
+Defaults to 0 which means that TTL check is disabled.   
+ 
 .It ip_target_host=HOST
 .It ip_target_port=PORT
 .It ip_target_protocol=PROTOCOL
@@ -856,7 +856,7 @@ Any message received with timestamp older than the specified amount of seconds w
 where messages circulate between modules.
 .El
 .SS ipclient (PI)
-The ipclient module collects any messages from senders and sends them over the network to another
+The ipclient module collects any messages from senders and sends them over the network to another 
 .B RRR
 environment's ipclient module using UDP. It may also accept connections from other clients and receive data,
 or a combination of these. An underlying UDP stream protocol ensures single delivery of
@@ -902,7 +902,7 @@ will only be attemted if IPv6 fails.
 If IPv6 succeeds, both IPv4 and IPv6 might actually be active depending on the operating system.
 
 .It ipclient_disallow_remote_ip_swap={yes|no}
-If yes and a remote changes its IP-address, RRR must restart before the new address can be accepted. Default is no.
+If yes and a remote changes its IP-address, RRR must restart before the new address can be accepted. Default is no. 
 .El
 .SS modbus (PA)
 This module implements a modbus client supporting the functions
@@ -912,9 +912,8 @@ and
 .PP
 The module is controlled using array command messages from sender instances, and there are no configuration parameters.
 .PP
-When a command is received, a connection is established with the specified modbus server and the request is sent. If
-.B modbus_oneshot_timeout_ms
-is not present the command may be repeated at a specified interval, and stops when an equal command has not been received for two seconds.
+When a command is received, a connection is established with the specified modbus server and polling starts.
+The command may be repeated at a specified interval, and stops when an equal command has not been received for two seconds.
 .PP
 The interval for a command may be changed by passing a command message with all other parameters being equal as another active command.
 .PP
@@ -966,19 +965,7 @@ The raw data to write in
 and
 .B Write Multiple Registers (0x10).
 .It modbus_interval_ms
-If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed. Only one of
-.B modbus_interval_ms
-or
-.B modbus_oneshot_timeout_ms
-may be present in a request.
-.It modbus_oneshot_timeout_ms
-If given, the command will only be sent once with the specified timeout. If the timeout occurs a response will be generated with the array field
-.B modbus_error
-present. Only one of
-.B modbus_interval_ms
-or
-.B modbus_oneshot_timeout_ms
-may be present in a request.
+If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed.
 .El
 .PP
 The following response messages and array fields are generated as a result of the modbus server
@@ -1015,10 +1002,10 @@ A one byte unsigned integer indicating an exception code.
 .It modbus_bytes
 A one byte unsigned integer indicating the size of a data field.
 .It modbus_status
-A blob containing response data from a
-.B Read Coils (0x01)
-or
-.B Read Discrete Inputs (0x02)
+A blob containing response data from a 
+.B Read Coils (0x01) 
+or 
+.B Read Discrete Inputs (0x02) 
 response of a length indicated by
 .B modbus_bytes.
 .It modbus_starting_address
@@ -1028,19 +1015,15 @@ or
 .B Write Multiple Registers (0x10)
 response.
 .It modbus_contents
-For
+For 
 .B Read Holding Registers (0x03), Read Input Registers (0x04)
 a blob containing response data from of a length indicated by
 .B modbus_bytes.
 .br
-For
+For 
 .B Write Single Register (0x06)
 a blob containing response data of length 2.
-.B
-.It modbus_error
-A string containing the reason for an internal RRR modbus error, as of now only
-.B oneshot_timeout
-supported.
+.B 
 .El
 .PP
 .SS python3 (PAI)
@@ -1123,13 +1106,13 @@ def process(socket : rrr_socket, message: rrr_message, method: str):
 	if my_global_variable == "":
 		print("Error: configuration failure\n")
 		return False
-
+		
 	# modify the retrieved message as needed
 	message.timestamp = message.timestamp + 1
-
+	
 	# queue the message to be sent back (optional) for python to give to readers
 	socket.send(message)
-
+	
 	return True
 
 def source(socket : rrr_socket, message : rrr_message):
@@ -1147,18 +1130,18 @@ def source(socket : rrr_socket, message : rrr_message):
 	# skip this step if the message are not to be sent, it is then simply discarded
 	# may be called multiple times with the same message
 	socket.send(message)
-
+	
 	# sleep to limit output rate
 	time.sleep(1)
 
 	return True
-
+	
 .EE
-More details about Python in
+More details about Python in 
 .Xr rrr_python3(5)
 .PP
 .SS perl5 (PAI)
-The perl5 module makes it possible to process and generate messages in a custom
+The perl5 module makes it possible to process and generate messages in a custom 
 perl script. The first and only argument to the source- and process-subs
 is the RRR message in the form of an object/hash reference of type
 .B rrr_message
@@ -1177,7 +1160,7 @@ It is possible to work with RRR array messages in the Perl script. This is done
 through calling dedicated functions on the
 .B rrr_message
 object received by source and process functions. The functions available are listed in the example scripts with comments.
-More details about types are found in
+More details about types are found in 
 .Xr rrr_post(1)
 .PP
 The following configuration parameters are available in the
@@ -1201,7 +1184,7 @@ of the current instance. The message may be modified or left alone.
 Optional name of a subroutine which receives an rrr::rrr_helper::rrr_settings object when the program
 is started. Any settings from the instance definition in the configuration file can be read from
 this object, also custom settings. Settings may also be modified and new settings can be added. The
-settings object may also be stored in the script to be read from or modified from the source- and
+settings object may also be stored in the script to be read from or modified from the source- and 
 generate-subroutines.
 
 .It CUSTOM SETTING=VALUE
@@ -1310,7 +1293,7 @@ Pushes an RRR fixed pointer type. If a string is given, string notation like
 is assumed.  If a double is given, it is converted directly from double to fixed point. If the value given will be stored as a 64-bit integer internally in perl, native fixed point will be assumed (this is difficult to control in a script).
 
 .It $message->push_tag(tag, value)
-Push a value or on array of values. The type will be identified automatically. Array values are passed by using a reference like
+Push a value or on array of values. The type will be identified automatically. Array values are passed by using a reference like 
 \\@my_array. If multiple values are given in an array, the must all have equal length.
 
 .It $message->clear_tag(tag)
@@ -1364,7 +1347,7 @@ function with loglevel 0.
 A variable must be blessed with the
 .B rrr_debug
 class to use the debug functions, look at the code below on how to do this. There are also commented out example
-calls to message print functions.
+calls to message print functions. 
 .PP
 Below follows an example perl script.
 .PP
@@ -1519,7 +1502,7 @@ sub process {
 }
 .EE
 .SS lua (PAI)
-The Lua module makes it possible to process and generate messages in a custom
+The Lua module makes it possible to process and generate messages in a custom 
 Lua script. The source function in the scripts receives an empty message object,
 and the process function receives populated messages from another module.
 Additional message objects may be created as well.
@@ -1633,9 +1616,9 @@ Set or get message type, use one of the constants from the Message object:
 RRR.Message.MSG_TYPE_MSG
 .It \(bu
 RRR.Message.MSG_TYPE_TAG
-.It \(bu
+.It \(bu 
 RRR.Message.MSG_TYPE_GET
-.It \(bu
+.It \(bu 
 RRR.Message.MSG_TYPE_PUT
 .It \(bu
 RRR.Message.MSG_TYPE_DEL
@@ -2042,7 +2025,7 @@ All custom cmodules will be run in separate forks.
 .PP
 The following confgiuration parameters are available in the
 .B cmodule
-module:
+module: 
 .PP
 .Bl -tag -width -indent
 .It cmodule_name=NAME
@@ -2095,7 +2078,7 @@ might be useful when working with for instance array messages are included in /s
 It is not a priority at this time to document these, but they are easy to use and usage examples are to
 be found throughout the RRR source code (which is human- and machine readable).
 .PP
-Functions must return 0 on success and 1 if there are errors.
+Functions must return 0 on success and 1 if there are errors.  
 .SS socket (SA)
 The socket module listens on a UNIX socket for RRR messages or custom data records.
 .PP
@@ -2115,11 +2098,11 @@ the socket exists. Defaults to no.
 An optional MQTT topic to set on the generated messages.
 
 .It socket_receive_rrr_message={yes|no}
-If set to
+If set to 
 .B yes
-, complete RRR messages are expected to be received on the socket. No array definition is to be specified.
+, complete RRR messages are expected to be received on the socket. No array definition is to be specified. 
 .Xr rrr_post(1)
-may generate such messages. If set to
+may generate such messages. If set to 
 .B no
 , an array definition must be specified, and RRR array messages will be produced from the received data. Defaults to no.
 
@@ -2179,7 +2162,7 @@ and
 .B http_server_get_response_from_senders
 for more details.
 
-Messages will not be generated for the
+Messages will not be generated for the 
 .B OPTIONS
 method, only default 204 responses will be sent to these requests.
 
@@ -2264,7 +2247,7 @@ This parameter is optional.
 
 .It http_server_fields_accept_any={yes|no}
 Accept any field names from incoming requests. May not be used with
-.B http_server_fields_accept.
+.B http_server_fields_accept. 
 Defaults to 'no'.
 
 .It http_server_no_body_parse={yes|no}
@@ -2277,7 +2260,7 @@ Allow messages with no array values to be generated. This option also affects
 If set to 'no' or left unset, messages will not be generated unless they would contain at least one array value.
 
 .It http_server_receive_full_request={yes|no}
-Get structural HTTP data from the request and add it to an RRR array message along with any fields.
+Get structural HTTP data from the request and add it to an RRR array message along with any fields. 
 The following array values will be present in generated messages:
 .sp
 .Bl -tag -width -indent
@@ -2372,7 +2355,7 @@ field.
 In any case, a content type header will not be sent if there is no response body.
 
 .It http_body
-The response body to send. The content type set in the response header, unless specified explititly in
+The response body to send. The content type set in the response header, unless specified explititly in 
 .B http_content_type,
 depends on the type of this field:
 
@@ -2427,11 +2410,11 @@ will send a
 header with the given string in all response headers.
 
 .It http_server_topic_format={simple|request}
-If set to
+If set to 
 .B simple
 or left unset,
-the generated messages will have the topic
-.B httpserver/request/uuu
+the generated messages will have the topic 
+.B httpserver/request/uuu 
 set. If set to
 .B request,
 the generated messages will have the topic
@@ -2502,7 +2485,7 @@ Messages received in httpserver with IDs not matching any active connections wil
 
 .It http_server_accept_websocket_binary={yes|no}
 Allow binary websocket frames. Data from such frames are put into plain RRR messages.
-If set to 'no' or left unset, received binary frames will be ignored.
+If set to 'no' or left unset, received binary frames will be ignored. 
 
 .It http_server_receive_websocket_rrr_message={yes|no}
 If set to 'yes' and websocket frames of binary type is received, these are interpreted as being RRR messages of any type.
@@ -2555,7 +2538,7 @@ will follow any redirects from the server, also to other servers.
 To disallow redirection, use the
 .B http_max_redirects
 parameter.
-
+ 
 .It http_endpoint=ENDPOINT
 The endpoint to request from the server, e.g.
 .B /index.php.
@@ -2684,7 +2667,7 @@ and
 .B raw
 format.
 The excact string specified in the array value with the matching tag will be used as Content-Type.
-Other requests are not affected.
+Other requests are not affected. 
 
 The parameters
 .B http_method_tag
@@ -2719,7 +2702,7 @@ controls whether or messages are generated for error responses.
 .It http_meta_tags_ignore={yes|no}
 Ignore any meta tags when array values to the HTTP query (controlled by)
 .B http_tags.
-If set to no, the meta fields may be added to query string or form data body as any other field. Defaults to yes.
+If set to no, the meta fields may be added to query string or form data body as any other field. Defaults to yes. 
 
 .It http_request_tags_ignore={yes|no}
 Ignore any tags possibly originating from
@@ -2868,9 +2851,9 @@ A good solution might be to have the server send one or more JSON objects repres
 A maximum of four object tree levels are parsed.
 
 Httpclient will attempt to parse any received data as JSON, regardless of what content type has been set.
-Should the parsing fail, no error messages are printed unless debuglevel 2 is set.
+Should the parsing fail, no error messages are printed unless debuglevel 2 is set.  
 
-If the original message which caused the query had a topic set, this topic will be present in generated messages.
+If the original message which caused the query had a topic set, this topic will be present in generated messages. 
 
 .It http_receive_structured={yes|no}
 If set to yes, generated messages will be RRR array messages. The following fields will be available in the messages:
@@ -2964,7 +2947,7 @@ Messages are stored with their filename being the SHA-256 hash of their topic. M
 
 Using the socket is the only way to communicate with the message DB, it cannot read from other modules nor can it be read from.
 
-Currently only internal modules may use the message DB, and the methods GET, PUT, DEL and IDX are available to them.
+Currently only internal modules may use the message DB, and the methods GET, PUT, DEL and IDX are available to them. 
 
 Messages are stored with all fields in network byte order. The may be deleted and moved in and out of the storage directory at any time, but any modifications
 may render message checksums invalid. The utility
@@ -3268,7 +3251,7 @@ RRR does not allow CONNECT packets only containing usernames, a password must al
 The permission name to which a user must have been registered with by using
 .Xr rrr_passwd(1)
 to become authenticated with this broker. Defaults to
-.B mqtt.
+.B mqtt. 
 
 .It mqtt_broker_require_authentication={yes|no}
 Disallow anonymous logins. This defaults to 'yes' if a password file is set, otherwise it defaults to 'no'.
@@ -3304,7 +3287,7 @@ access is granted, a user may SUBSCRIBE to the matching topics. If
 .B WRITE
 access is granted, a user may SUBSCRIBE and PUBLISH to the matching topics.
 .B DENY
-will block all access to the matching topics.
+will block all access to the matching topics. 
 .PP
 The ACL file is parsed from top to bottom, and the bottom most matching rule will take precedence.
 .PP
@@ -3385,7 +3368,7 @@ to avoid non-processed messages filling up memory in situations where the broker
 is 'restart', all messages will be cleared anyway when all instances restart after mqttclient fails to connect.
 .B mqtt_discard_on_connect_retry
 may not be set to 'yes' in this situation. Defaults to 'no'.
-
+  
 .It mqtt_username=USERNAME
 .It mqtt_password=PASSWORD
 Optional username and password to send in CONNECT packets. If a password is set, a username
@@ -3461,7 +3444,7 @@ If the contents of the array value is an unsigned number, this is used to set th
 The broker will delete the retained message after the specified amount of seconds has passed.
 If the number is set to 0 or if the active protocol version is not 5, the retain message will never expire.
 
-If the contents of the array value is anything else or not present, the contents is ignored.
+If the contents of the array value is anything else or not present, the contents is ignored. 
 
 .It mqtt_publish_array_values={*|tag1[,tag2[,...]]}
 Put all values from an array (*) or selected values (by tag) into the payload of PUBLISH messages. RRR
@@ -3488,7 +3471,7 @@ If set to 'no' or left unset, the RRR message will retain is original topic, if 
 If set, expect to receive data arrays of specific formats in publish messages.
 This option cannot be used with mqtt_receive_rrr_message=yes, however if protocol version is V5,
 received RRR messages will still be auto-detected, and array parsing will not occur for these.
-Multiple data array records may reside in a single PUBLISH message, one RRR message will be generated for each record.
+Multiple data array records may reside in a single PUBLISH message, one RRR message will be generated for each record. 
 Refer to
 .Xr rrr_post(1)
 for syntax of array definitions.
@@ -3542,7 +3525,7 @@ If a global debuglevel other than 1 is active, ...
 \(bu all messages with a loglevel other 1 will be suppressed.
 .br
 \(bu messages from custom scripts which generate log messages (regardless of debuglevel) on other loglevels than 1 will be suppressed.
-.br
+.br  
 \(bu all log messages are still delivered to
 .Xr rrr_stats(1)
 and printed out (and delivered to syslog if RRR is an systemd daemon).
@@ -3736,7 +3719,7 @@ The original and resolved path (in case original is a symbolic link) of the file
 .It atime
 .It mtime
 .It ctime
-Timestamps in epoch format with second resolution. Describe file access time, modification time and creation time.
+Timestamps in epoch format with second resolution. Describe file access time, modification time and creation time. 
 .El
 
 If set to 'file', the contents of the file along with metadata is put into an array with the following fields:
@@ -3786,7 +3769,7 @@ If set, set a speed int bits per second like 19200, 38400 etc. on serial serial 
 If set and set to 'even' or 'odd', parity will be set accordingly on serial ports. If set to 'none', parity will be forced off. If left unset, parity settings will be left untouched.
 
 .It file_serial_two_stop_bits={yes|no}
-If set to yes, use two stop bits on serial ports. If set to no, force one stop bit to be used. If left unset, stop bit configuration is left untouched.
+If set to yes, use two stop bits on serial ports. If set to no, force one stop bit to be used. If left unset, stop bit configuration is left untouched. 
 
 .It file_try_keyboard_input={yes|no} (LINUX/FREEBSD ONLY)
 If set to yes, and character devices are found in the directory,
@@ -3807,7 +3790,7 @@ Defaults to no.
 
 .It file_no_keyboard_hijack={yes|no}
 After a keyboard device has been successfully hijacked thus identified as a keyboard, immediately
-ungrab the device so that other applications also may receive events from it.
+ungrab the device so that other applications also may receive events from it. 
 
 .It file_max_messages_per_file=COUNT
 After the specified amount of messages has been read rom a file, close it.
@@ -3822,7 +3805,7 @@ Must be greater than zero, defaults to 4096.
 .It file_timeout_s=SECONDS
 If no message is read or written in the specified amount of seconds, close the file.
 Any messages not yet written are dropped.
-Defaults to 0 which means no timeout.
+Defaults to 0 which means no timeout. 
 
 .It file_write_timeout_ms=MILLISECONDS
 If a particular message to write is not written within this time, it is dropped.
@@ -3832,7 +3815,7 @@ Defaults to 0 which means no timeout.
 
 .It file_ttl_seconds=SECONDS
 Check the creation timestamp of messages and drop them if they are or become older than the specified amount of seconds.
-Defaults to 0 which means that TTL check is disabled.
+Defaults to 0 which means that TTL check is disabled.   
 
 .It file_write_array_values={*|tag1[,tag2[,...]]}
 Put all values from an array (*) or selected values (by tag) into the file.
@@ -3874,7 +3857,7 @@ For write to be possible, proper permissions must be given (read + write permiss
 
 .El
 .SS mysql (DAI)
-This module will read in messages from other modules, possibly IP-capable, and save them to a myqsl or MariaDB
+This module will read in messages from other modules, possibly IP-capable, and save them to a myqsl or MariaDB 
 database.
 .PP
 A column plan must be used to describe the table we are saving to. The received data must match this column plan. If
@@ -3972,7 +3955,7 @@ A comma separated list of items to retrieve from the received array messages and
 in InfluxDB. If the tag of an
 item in an array is not equal to the tag in InfluxDB, the tag may be followed by
 .B ->INFLUXDB TAG
-to translate the tag name.
+to translate the tag name. 
 Items in an array message which are not tagged cannot be used.
 
 .It influxdb_fields=ARRAY TAG[->INFLUXDB FIELD][,...]
@@ -4125,7 +4108,7 @@ Converts blob or blob-ish fields to blobs. No data manipulation is performed.
 
 .TP 10
 .B blob2hex
-Converts blob or blob-ish fields to hexadecimal ASCII stored in str types. The output size will be exactly double the input size.
+Converts blob or blob-ish fields to hexadecimal ASCII stored in str types. The output size will be exactly double the input size. 
 
 .TP 10
 .B str2str
@@ -4147,7 +4130,7 @@ Overflow is not handled, and numbers may become truncated.
 Converts str fields which are empty to vain.
 
 .TP 10
-.B msg2blob
+.B msg2blob       
 Converts msg fields to blobs. No data manipulation is performed.
 
 .TP 10

--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -912,11 +912,14 @@ and
 .PP
 The module is controlled using array command messages from sender instances, and there are no configuration parameters.
 .PP
-When a command is received, a connection is established with the specified modbus server and the request is sent. If
+When a command is received, a connection is established with the specified modbus server and the request is sent. The configuration parameters
 .B modbus_oneshot_timeout_ms
-is not present the command may be repeated at a specified interval, and stops when an equal command has not been received for two seconds.
+and
+.B modbus_interval_ms
+controls wether or not a command is to be repeated or sent only once.
 .PP
 The interval for a command may be changed by passing a command message with all other parameters being equal as another active command.
+After a command has been received, it is repeated for at most two seconds at the given interval.
 .PP
 If different commands are used on the same server, they will share connection.
 .PP
@@ -966,19 +969,16 @@ The raw data to write in
 and
 .B Write Multiple Registers (0x10).
 .It modbus_interval_ms
-If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed. Only one of
-.B modbus_interval_ms
-or
+If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed. May not
+be given if
 .B modbus_oneshot_timeout_ms
-may be present in a request.
+is given.
 .It modbus_oneshot_timeout_ms
 If given, the command will only be sent once with the specified timeout. If the timeout occurs a response will be generated with the array field
 .B modbus_error
-present. Must be equal or greater than 0. Only one of
+present. Must be equal or greater than 0. May not be given if
 .B modbus_interval_ms
-or
-.B modbus_oneshot_timeout_ms
-may be present in a request.
+is given.
 .El
 .PP
 The following response messages and array fields are generated as a result of the modbus server
@@ -1038,9 +1038,12 @@ For
 a blob containing response data of length 2.
 .B
 .It modbus_error
-A string containing the reason for an internal RRR modbus error, as of now only
-.B oneshot_timeout
-supported.
+A string containing the reason for an internal RRR modbus error. Is either not set or has one of the following values:
+.Bl -tag -width -indent
+.It oneshot_timeout
+Indicates that the timeout for a one-shot request set in
+.B modbus_oneshot_timeout_ms
+was reached and that no response was received.
 .El
 .PP
 .SS python3 (PAI)

--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -912,8 +912,9 @@ and
 .PP
 The module is controlled using array command messages from sender instances, and there are no configuration parameters.
 .PP
-When a command is received, a connection is established with the specified modbus server and polling starts.
-The command may be repeated at a specified interval, and stops when an equal command has not been received for two seconds.
+When a command is received, a connection is established with the specified modbus server and the request is sent. If
+.B modbus_oneshot_timeout_ms
+is not present the command may be repeated at a specified interval, and stops when an equal command has not been received for two seconds.
 .PP
 The interval for a command may be changed by passing a command message with all other parameters being equal as another active command.
 .PP
@@ -965,7 +966,19 @@ The raw data to write in
 and
 .B Write Multiple Registers (0x10).
 .It modbus_interval_ms
-If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed.
+If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed. Only one of
+.B modbus_interval_ms
+or
+.B modbus_oneshot_timeout_ms
+may be present in a request.
+.It modbus_oneshot_timeout_ms
+If given, the command will only be sent once with the specified timeout. If the timeout occurs a response will be generated with the array field
+.B modbus_error
+present. Only one of
+.B modbus_interval_ms
+or
+.B modbus_oneshot_timeout_ms
+may be present in a request.
 .El
 .PP
 The following response messages and array fields are generated as a result of the modbus server
@@ -1015,15 +1028,19 @@ or
 .B Write Multiple Registers (0x10)
 response.
 .It modbus_contents
-For 
+For
 .B Read Holding Registers (0x03), Read Input Registers (0x04)
 a blob containing response data from of a length indicated by
 .B modbus_bytes.
 .br
-For 
+For
 .B Write Single Register (0x06)
 a blob containing response data of length 2.
-.B 
+.B
+.It modbus_error
+A string containing the reason for an internal RRR modbus error, as of now only
+.B oneshot_timeout
+supported.
 .El
 .PP
 .SS python3 (PAI)

--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -974,7 +974,7 @@ may be present in a request.
 .It modbus_oneshot_timeout_ms
 If given, the command will only be sent once with the specified timeout. If the timeout occurs a response will be generated with the array field
 .B modbus_error
-present. Only one of
+present. Must be equal or greater than 0. Only one of
 .B modbus_interval_ms
 or
 .B modbus_oneshot_timeout_ms

--- a/misc/man/rrr.conf.5
+++ b/misc/man/rrr.conf.5
@@ -175,7 +175,7 @@ sep1#separator
 	# Push two topic filters to the stack
 	T my_topic_a/+
 	T my_topic_b/+
-	# Run OR operator on the two stack values, leaves a boolean value on the stack 
+	# Run OR operator on the two stack values, leaves a boolean value on the stack
 	OR
 	# Set the reader instance_receier_1 to receive messages matching one of the filters
 	D instance_receiver_1
@@ -214,7 +214,7 @@ sep1#separator
 	# Push two topic filters to the stack
 	T my_topic_a/+
 	T my_topic_b/+
-	# Run OR operator on the two stack values, leaves a boolean value on the stack 
+	# Run OR operator on the two stack values, leaves a boolean value on the stack
 	OR
 	# Push a method name to the stack and apply the name. Bail out if a method was set.
 	M method_topic
@@ -253,7 +253,7 @@ types to be specified in their configuration. If the total size of the input doe
 of the message will fail. Some modules also generate array messages internally, and they can be created within Perl and
 Python scripts. Fields from an HTTP request can be mapped into an array, and an array can be mapped into database columns.
 .PP
-The general syntax for an array parsing specification (without branches) is a comma separated list of types with length and item count specifications. 
+The general syntax for an array parsing specification (without branches) is a comma separated list of types with length and item count specifications.
 .PP
 .Dl type1[length1][@count1][#tag1][,type2[length2][@count2][#tag2]][,...]
 .PP
@@ -289,7 +289,7 @@ section of
 for the complete specification of all the types, and the specification for array trees (branching with IF-blocks).
 .SS IP MESSAGES
 Some messages contain IP data, for instance messages created by a module which reads from the network. The address
-of the sender will be contained within the message. All modules may use IP-messages, but not all of them use the IP-data. 
+of the sender will be contained within the message. All modules may use IP-messages, but not all of them use the IP-data.
 .SH BUFFERS
 .PP
 Each instance of a source or processor module has an output buffer from which other modules read. If buffer is
@@ -436,12 +436,12 @@ Module supports data arrays
 Module supports IP messages
 .El
 .PP
-All modules support array and/or IP-messages, also those who do not have  
+All modules support array and/or IP-messages, also those who do not have
 .B A
 or
 .B I
 specified. Array- and IP-capable modules may however use or modify data from such messages.
-Messages may have both IP- and Array-data simultaneously. 
+Messages may have both IP- and Array-data simultaneously.
 .PP
 The following modules are available, they are discussed in detail further down.
 .PP
@@ -456,10 +456,10 @@ Dumps messages, used for debugging and performance measurements.
 Handles IP communication, UDP and TCP.
 
 .It exploder (PA)
-Splits RRR array messages into multiple messages. 
+Splits RRR array messages into multiple messages.
 
 .It mangler (PA)
-Converts between data types in RRR arrays. 
+Converts between data types in RRR arrays.
 
 .It buffer (P)
 Buffers messages, may be used to duplicate messages to multiple readers.
@@ -605,7 +605,7 @@ If left unspecified, no listening takes place.
 .It ip_input_types=ARRAY DEFINITION
 Specification of expected data to receive from remote. See
 .Xr rrr_post(1)
-for the syntax. 
+for the syntax.
 To receive RRR messages, set the definition to
 .B msg
 and set
@@ -618,7 +618,7 @@ Array data on UDP will only be read if an UDP listening port is set.
 .It ip_strip_array_separators={yes|no}
 If set to yes, any array fields of the
 .B sep
-type is stripped out before RRR array messages are created. Defaults to no.  
+type is stripped out before RRR array messages are created. Defaults to no.
 
 .It ip_extract_rrr_messages={yes|no}
 Extract any RRR messages from the received data (if specified in ip_input_types) and save them in the buffer for other modules to pick up.
@@ -682,7 +682,7 @@ Default is no timeout (same as 0).
 .It ip_smart_timeout={yes|no}
 If set to yes and a message is successfully sent, reset the timeout counter for all other unsent messages destined for the same host, port and protocol currently in the queue.
 If set to no, unsent messages will time out according to the current send timeout regardless of whether other messages to the same destination have been sent or not in the meantime.
-Defaults to no. 
+Defaults to no.
 
 .It ip_timeout_action={retry|drop|return}
 What do do when a message times out after being undeliverable. In case of
@@ -696,7 +696,7 @@ the destination address if the target host is unreachable, and possibly log erro
 .B retry
 is used, then
 .B ip_send_timeout
-must be set to zero or left undefined. 
+must be set to zero or left undefined.
 
 .It ip_graylist_timeout_ms=MILLISECONDS
 If a TCP destination is unreachable, add it to the graylist and retry only after the specified  number of milliseconds has passed.
@@ -712,8 +712,8 @@ The TTL check is not the same as the send timeout, it does not respect
 nor
 .B ip_smart_timeout.
 TTL expiration also applies to partially sent messages.
-Defaults to 0 which means that TTL check is disabled.   
- 
+Defaults to 0 which means that TTL check is disabled.
+
 .It ip_target_host=HOST
 .It ip_target_port=PORT
 .It ip_target_protocol=PROTOCOL
@@ -856,7 +856,7 @@ Any message received with timestamp older than the specified amount of seconds w
 where messages circulate between modules.
 .El
 .SS ipclient (PI)
-The ipclient module collects any messages from senders and sends them over the network to another 
+The ipclient module collects any messages from senders and sends them over the network to another
 .B RRR
 environment's ipclient module using UDP. It may also accept connections from other clients and receive data,
 or a combination of these. An underlying UDP stream protocol ensures single delivery of
@@ -902,7 +902,7 @@ will only be attemted if IPv6 fails.
 If IPv6 succeeds, both IPv4 and IPv6 might actually be active depending on the operating system.
 
 .It ipclient_disallow_remote_ip_swap={yes|no}
-If yes and a remote changes its IP-address, RRR must restart before the new address can be accepted. Default is no. 
+If yes and a remote changes its IP-address, RRR must restart before the new address can be accepted. Default is no.
 .El
 .SS modbus (PA)
 This module implements a modbus client supporting the functions
@@ -912,8 +912,9 @@ and
 .PP
 The module is controlled using array command messages from sender instances, and there are no configuration parameters.
 .PP
-When a command is received, a connection is established with the specified modbus server and polling starts.
-The command may be repeated at a specified interval, and stops when an equal command has not been received for two seconds.
+When a command is received, a connection is established with the specified modbus server and the request is sent. If
+.B modbus_oneshot_timeout_ms
+is not present the command may be repeated at a specified interval, and stops when an equal command has not been received for two seconds.
 .PP
 The interval for a command may be changed by passing a command message with all other parameters being equal as another active command.
 .PP
@@ -965,7 +966,19 @@ The raw data to write in
 and
 .B Write Multiple Registers (0x10).
 .It modbus_interval_ms
-If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed.
+If given, the command is repeated at the given interval for two seconds. Defaults to 0 which means that repeat is not performed. Only one of
+.B modbus_interval_ms
+or
+.B modbus_oneshot_timeout_ms
+may be present in a request.
+.It modbus_oneshot_timeout_ms
+If given, the command will only be sent once with the specified timeout. If the timeout occurs a response will be generated with the array field
+.B modbus_error
+present. Only one of
+.B modbus_interval_ms
+or
+.B modbus_oneshot_timeout_ms
+may be present in a request.
 .El
 .PP
 The following response messages and array fields are generated as a result of the modbus server
@@ -1002,10 +1015,10 @@ A one byte unsigned integer indicating an exception code.
 .It modbus_bytes
 A one byte unsigned integer indicating the size of a data field.
 .It modbus_status
-A blob containing response data from a 
-.B Read Coils (0x01) 
-or 
-.B Read Discrete Inputs (0x02) 
+A blob containing response data from a
+.B Read Coils (0x01)
+or
+.B Read Discrete Inputs (0x02)
 response of a length indicated by
 .B modbus_bytes.
 .It modbus_starting_address
@@ -1015,15 +1028,19 @@ or
 .B Write Multiple Registers (0x10)
 response.
 .It modbus_contents
-For 
+For
 .B Read Holding Registers (0x03), Read Input Registers (0x04)
 a blob containing response data from of a length indicated by
 .B modbus_bytes.
 .br
-For 
+For
 .B Write Single Register (0x06)
 a blob containing response data of length 2.
-.B 
+.B
+.It modbus_error
+A string containing the reason for an internal RRR modbus error, as of now only
+.B oneshot_timeout
+supported.
 .El
 .PP
 .SS python3 (PAI)
@@ -1106,13 +1123,13 @@ def process(socket : rrr_socket, message: rrr_message, method: str):
 	if my_global_variable == "":
 		print("Error: configuration failure\n")
 		return False
-		
+
 	# modify the retrieved message as needed
 	message.timestamp = message.timestamp + 1
-	
+
 	# queue the message to be sent back (optional) for python to give to readers
 	socket.send(message)
-	
+
 	return True
 
 def source(socket : rrr_socket, message : rrr_message):
@@ -1130,18 +1147,18 @@ def source(socket : rrr_socket, message : rrr_message):
 	# skip this step if the message are not to be sent, it is then simply discarded
 	# may be called multiple times with the same message
 	socket.send(message)
-	
+
 	# sleep to limit output rate
 	time.sleep(1)
 
 	return True
-	
+
 .EE
-More details about Python in 
+More details about Python in
 .Xr rrr_python3(5)
 .PP
 .SS perl5 (PAI)
-The perl5 module makes it possible to process and generate messages in a custom 
+The perl5 module makes it possible to process and generate messages in a custom
 perl script. The first and only argument to the source- and process-subs
 is the RRR message in the form of an object/hash reference of type
 .B rrr_message
@@ -1160,7 +1177,7 @@ It is possible to work with RRR array messages in the Perl script. This is done
 through calling dedicated functions on the
 .B rrr_message
 object received by source and process functions. The functions available are listed in the example scripts with comments.
-More details about types are found in 
+More details about types are found in
 .Xr rrr_post(1)
 .PP
 The following configuration parameters are available in the
@@ -1184,7 +1201,7 @@ of the current instance. The message may be modified or left alone.
 Optional name of a subroutine which receives an rrr::rrr_helper::rrr_settings object when the program
 is started. Any settings from the instance definition in the configuration file can be read from
 this object, also custom settings. Settings may also be modified and new settings can be added. The
-settings object may also be stored in the script to be read from or modified from the source- and 
+settings object may also be stored in the script to be read from or modified from the source- and
 generate-subroutines.
 
 .It CUSTOM SETTING=VALUE
@@ -1293,7 +1310,7 @@ Pushes an RRR fixed pointer type. If a string is given, string notation like
 is assumed.  If a double is given, it is converted directly from double to fixed point. If the value given will be stored as a 64-bit integer internally in perl, native fixed point will be assumed (this is difficult to control in a script).
 
 .It $message->push_tag(tag, value)
-Push a value or on array of values. The type will be identified automatically. Array values are passed by using a reference like 
+Push a value or on array of values. The type will be identified automatically. Array values are passed by using a reference like
 \\@my_array. If multiple values are given in an array, the must all have equal length.
 
 .It $message->clear_tag(tag)
@@ -1347,7 +1364,7 @@ function with loglevel 0.
 A variable must be blessed with the
 .B rrr_debug
 class to use the debug functions, look at the code below on how to do this. There are also commented out example
-calls to message print functions. 
+calls to message print functions.
 .PP
 Below follows an example perl script.
 .PP
@@ -1502,7 +1519,7 @@ sub process {
 }
 .EE
 .SS lua (PAI)
-The Lua module makes it possible to process and generate messages in a custom 
+The Lua module makes it possible to process and generate messages in a custom
 Lua script. The source function in the scripts receives an empty message object,
 and the process function receives populated messages from another module.
 Additional message objects may be created as well.
@@ -1616,9 +1633,9 @@ Set or get message type, use one of the constants from the Message object:
 RRR.Message.MSG_TYPE_MSG
 .It \(bu
 RRR.Message.MSG_TYPE_TAG
-.It \(bu 
+.It \(bu
 RRR.Message.MSG_TYPE_GET
-.It \(bu 
+.It \(bu
 RRR.Message.MSG_TYPE_PUT
 .It \(bu
 RRR.Message.MSG_TYPE_DEL
@@ -2025,7 +2042,7 @@ All custom cmodules will be run in separate forks.
 .PP
 The following confgiuration parameters are available in the
 .B cmodule
-module: 
+module:
 .PP
 .Bl -tag -width -indent
 .It cmodule_name=NAME
@@ -2078,7 +2095,7 @@ might be useful when working with for instance array messages are included in /s
 It is not a priority at this time to document these, but they are easy to use and usage examples are to
 be found throughout the RRR source code (which is human- and machine readable).
 .PP
-Functions must return 0 on success and 1 if there are errors.  
+Functions must return 0 on success and 1 if there are errors.
 .SS socket (SA)
 The socket module listens on a UNIX socket for RRR messages or custom data records.
 .PP
@@ -2098,11 +2115,11 @@ the socket exists. Defaults to no.
 An optional MQTT topic to set on the generated messages.
 
 .It socket_receive_rrr_message={yes|no}
-If set to 
+If set to
 .B yes
-, complete RRR messages are expected to be received on the socket. No array definition is to be specified. 
+, complete RRR messages are expected to be received on the socket. No array definition is to be specified.
 .Xr rrr_post(1)
-may generate such messages. If set to 
+may generate such messages. If set to
 .B no
 , an array definition must be specified, and RRR array messages will be produced from the received data. Defaults to no.
 
@@ -2162,7 +2179,7 @@ and
 .B http_server_get_response_from_senders
 for more details.
 
-Messages will not be generated for the 
+Messages will not be generated for the
 .B OPTIONS
 method, only default 204 responses will be sent to these requests.
 
@@ -2247,7 +2264,7 @@ This parameter is optional.
 
 .It http_server_fields_accept_any={yes|no}
 Accept any field names from incoming requests. May not be used with
-.B http_server_fields_accept. 
+.B http_server_fields_accept.
 Defaults to 'no'.
 
 .It http_server_no_body_parse={yes|no}
@@ -2260,7 +2277,7 @@ Allow messages with no array values to be generated. This option also affects
 If set to 'no' or left unset, messages will not be generated unless they would contain at least one array value.
 
 .It http_server_receive_full_request={yes|no}
-Get structural HTTP data from the request and add it to an RRR array message along with any fields. 
+Get structural HTTP data from the request and add it to an RRR array message along with any fields.
 The following array values will be present in generated messages:
 .sp
 .Bl -tag -width -indent
@@ -2355,7 +2372,7 @@ field.
 In any case, a content type header will not be sent if there is no response body.
 
 .It http_body
-The response body to send. The content type set in the response header, unless specified explititly in 
+The response body to send. The content type set in the response header, unless specified explititly in
 .B http_content_type,
 depends on the type of this field:
 
@@ -2410,11 +2427,11 @@ will send a
 header with the given string in all response headers.
 
 .It http_server_topic_format={simple|request}
-If set to 
+If set to
 .B simple
 or left unset,
-the generated messages will have the topic 
-.B httpserver/request/uuu 
+the generated messages will have the topic
+.B httpserver/request/uuu
 set. If set to
 .B request,
 the generated messages will have the topic
@@ -2485,7 +2502,7 @@ Messages received in httpserver with IDs not matching any active connections wil
 
 .It http_server_accept_websocket_binary={yes|no}
 Allow binary websocket frames. Data from such frames are put into plain RRR messages.
-If set to 'no' or left unset, received binary frames will be ignored. 
+If set to 'no' or left unset, received binary frames will be ignored.
 
 .It http_server_receive_websocket_rrr_message={yes|no}
 If set to 'yes' and websocket frames of binary type is received, these are interpreted as being RRR messages of any type.
@@ -2538,7 +2555,7 @@ will follow any redirects from the server, also to other servers.
 To disallow redirection, use the
 .B http_max_redirects
 parameter.
- 
+
 .It http_endpoint=ENDPOINT
 The endpoint to request from the server, e.g.
 .B /index.php.
@@ -2667,7 +2684,7 @@ and
 .B raw
 format.
 The excact string specified in the array value with the matching tag will be used as Content-Type.
-Other requests are not affected. 
+Other requests are not affected.
 
 The parameters
 .B http_method_tag
@@ -2702,7 +2719,7 @@ controls whether or messages are generated for error responses.
 .It http_meta_tags_ignore={yes|no}
 Ignore any meta tags when array values to the HTTP query (controlled by)
 .B http_tags.
-If set to no, the meta fields may be added to query string or form data body as any other field. Defaults to yes. 
+If set to no, the meta fields may be added to query string or form data body as any other field. Defaults to yes.
 
 .It http_request_tags_ignore={yes|no}
 Ignore any tags possibly originating from
@@ -2851,9 +2868,9 @@ A good solution might be to have the server send one or more JSON objects repres
 A maximum of four object tree levels are parsed.
 
 Httpclient will attempt to parse any received data as JSON, regardless of what content type has been set.
-Should the parsing fail, no error messages are printed unless debuglevel 2 is set.  
+Should the parsing fail, no error messages are printed unless debuglevel 2 is set.
 
-If the original message which caused the query had a topic set, this topic will be present in generated messages. 
+If the original message which caused the query had a topic set, this topic will be present in generated messages.
 
 .It http_receive_structured={yes|no}
 If set to yes, generated messages will be RRR array messages. The following fields will be available in the messages:
@@ -2947,7 +2964,7 @@ Messages are stored with their filename being the SHA-256 hash of their topic. M
 
 Using the socket is the only way to communicate with the message DB, it cannot read from other modules nor can it be read from.
 
-Currently only internal modules may use the message DB, and the methods GET, PUT, DEL and IDX are available to them. 
+Currently only internal modules may use the message DB, and the methods GET, PUT, DEL and IDX are available to them.
 
 Messages are stored with all fields in network byte order. The may be deleted and moved in and out of the storage directory at any time, but any modifications
 may render message checksums invalid. The utility
@@ -3251,7 +3268,7 @@ RRR does not allow CONNECT packets only containing usernames, a password must al
 The permission name to which a user must have been registered with by using
 .Xr rrr_passwd(1)
 to become authenticated with this broker. Defaults to
-.B mqtt. 
+.B mqtt.
 
 .It mqtt_broker_require_authentication={yes|no}
 Disallow anonymous logins. This defaults to 'yes' if a password file is set, otherwise it defaults to 'no'.
@@ -3287,7 +3304,7 @@ access is granted, a user may SUBSCRIBE to the matching topics. If
 .B WRITE
 access is granted, a user may SUBSCRIBE and PUBLISH to the matching topics.
 .B DENY
-will block all access to the matching topics. 
+will block all access to the matching topics.
 .PP
 The ACL file is parsed from top to bottom, and the bottom most matching rule will take precedence.
 .PP
@@ -3368,7 +3385,7 @@ to avoid non-processed messages filling up memory in situations where the broker
 is 'restart', all messages will be cleared anyway when all instances restart after mqttclient fails to connect.
 .B mqtt_discard_on_connect_retry
 may not be set to 'yes' in this situation. Defaults to 'no'.
-  
+
 .It mqtt_username=USERNAME
 .It mqtt_password=PASSWORD
 Optional username and password to send in CONNECT packets. If a password is set, a username
@@ -3444,7 +3461,7 @@ If the contents of the array value is an unsigned number, this is used to set th
 The broker will delete the retained message after the specified amount of seconds has passed.
 If the number is set to 0 or if the active protocol version is not 5, the retain message will never expire.
 
-If the contents of the array value is anything else or not present, the contents is ignored. 
+If the contents of the array value is anything else or not present, the contents is ignored.
 
 .It mqtt_publish_array_values={*|tag1[,tag2[,...]]}
 Put all values from an array (*) or selected values (by tag) into the payload of PUBLISH messages. RRR
@@ -3471,7 +3488,7 @@ If set to 'no' or left unset, the RRR message will retain is original topic, if 
 If set, expect to receive data arrays of specific formats in publish messages.
 This option cannot be used with mqtt_receive_rrr_message=yes, however if protocol version is V5,
 received RRR messages will still be auto-detected, and array parsing will not occur for these.
-Multiple data array records may reside in a single PUBLISH message, one RRR message will be generated for each record. 
+Multiple data array records may reside in a single PUBLISH message, one RRR message will be generated for each record.
 Refer to
 .Xr rrr_post(1)
 for syntax of array definitions.
@@ -3525,7 +3542,7 @@ If a global debuglevel other than 1 is active, ...
 \(bu all messages with a loglevel other 1 will be suppressed.
 .br
 \(bu messages from custom scripts which generate log messages (regardless of debuglevel) on other loglevels than 1 will be suppressed.
-.br  
+.br
 \(bu all log messages are still delivered to
 .Xr rrr_stats(1)
 and printed out (and delivered to syslog if RRR is an systemd daemon).
@@ -3719,7 +3736,7 @@ The original and resolved path (in case original is a symbolic link) of the file
 .It atime
 .It mtime
 .It ctime
-Timestamps in epoch format with second resolution. Describe file access time, modification time and creation time. 
+Timestamps in epoch format with second resolution. Describe file access time, modification time and creation time.
 .El
 
 If set to 'file', the contents of the file along with metadata is put into an array with the following fields:
@@ -3769,7 +3786,7 @@ If set, set a speed int bits per second like 19200, 38400 etc. on serial serial 
 If set and set to 'even' or 'odd', parity will be set accordingly on serial ports. If set to 'none', parity will be forced off. If left unset, parity settings will be left untouched.
 
 .It file_serial_two_stop_bits={yes|no}
-If set to yes, use two stop bits on serial ports. If set to no, force one stop bit to be used. If left unset, stop bit configuration is left untouched. 
+If set to yes, use two stop bits on serial ports. If set to no, force one stop bit to be used. If left unset, stop bit configuration is left untouched.
 
 .It file_try_keyboard_input={yes|no} (LINUX/FREEBSD ONLY)
 If set to yes, and character devices are found in the directory,
@@ -3790,7 +3807,7 @@ Defaults to no.
 
 .It file_no_keyboard_hijack={yes|no}
 After a keyboard device has been successfully hijacked thus identified as a keyboard, immediately
-ungrab the device so that other applications also may receive events from it. 
+ungrab the device so that other applications also may receive events from it.
 
 .It file_max_messages_per_file=COUNT
 After the specified amount of messages has been read rom a file, close it.
@@ -3805,7 +3822,7 @@ Must be greater than zero, defaults to 4096.
 .It file_timeout_s=SECONDS
 If no message is read or written in the specified amount of seconds, close the file.
 Any messages not yet written are dropped.
-Defaults to 0 which means no timeout. 
+Defaults to 0 which means no timeout.
 
 .It file_write_timeout_ms=MILLISECONDS
 If a particular message to write is not written within this time, it is dropped.
@@ -3815,7 +3832,7 @@ Defaults to 0 which means no timeout.
 
 .It file_ttl_seconds=SECONDS
 Check the creation timestamp of messages and drop them if they are or become older than the specified amount of seconds.
-Defaults to 0 which means that TTL check is disabled.   
+Defaults to 0 which means that TTL check is disabled.
 
 .It file_write_array_values={*|tag1[,tag2[,...]]}
 Put all values from an array (*) or selected values (by tag) into the file.
@@ -3857,7 +3874,7 @@ For write to be possible, proper permissions must be given (read + write permiss
 
 .El
 .SS mysql (DAI)
-This module will read in messages from other modules, possibly IP-capable, and save them to a myqsl or MariaDB 
+This module will read in messages from other modules, possibly IP-capable, and save them to a myqsl or MariaDB
 database.
 .PP
 A column plan must be used to describe the table we are saving to. The received data must match this column plan. If
@@ -3955,7 +3972,7 @@ A comma separated list of items to retrieve from the received array messages and
 in InfluxDB. If the tag of an
 item in an array is not equal to the tag in InfluxDB, the tag may be followed by
 .B ->INFLUXDB TAG
-to translate the tag name. 
+to translate the tag name.
 Items in an array message which are not tagged cannot be used.
 
 .It influxdb_fields=ARRAY TAG[->INFLUXDB FIELD][,...]
@@ -4108,7 +4125,7 @@ Converts blob or blob-ish fields to blobs. No data manipulation is performed.
 
 .TP 10
 .B blob2hex
-Converts blob or blob-ish fields to hexadecimal ASCII stored in str types. The output size will be exactly double the input size. 
+Converts blob or blob-ish fields to hexadecimal ASCII stored in str types. The output size will be exactly double the input size.
 
 .TP 10
 .B str2str
@@ -4130,7 +4147,7 @@ Overflow is not handled, and numbers may become truncated.
 Converts str fields which are empty to vain.
 
 .TP 10
-.B msg2blob       
+.B msg2blob
 Converts msg fields to blobs. No data manipulation is performed.
 
 .TP 10

--- a/src/modules/p_modbus.c
+++ b/src/modules/p_modbus.c
@@ -1293,6 +1293,12 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 			goto drop;
 		}
 	}
+	else {
+		/*
+		 * As no one was present both interval_ms and oneshot_timeout_ms are now set to 0.
+		 * When oneshout_timeout_ms is 0 the request will be treated as an interval request.
+		 */
+	}
 
 	if (modbus_function == RRR_MODBUS_FUNCTION_CODE_06_WRITE_SINGLE_REGISTER ||
 		modbus_function == RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTERS) {

--- a/src/modules/p_modbus.c
+++ b/src/modules/p_modbus.c
@@ -57,6 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MODBUS_DEFAULT_QUANTITY_WRITE_SINGLE_REGISTER 1
 
 #define MODBUS_DEFAULT_INTERVAL_MS 0
+#define MODBUS_DEFAULT_ONESHOT_TIMEOUT_MS 0
 #define MODBUS_DEFAULT_RESPONSE_TOPIC NULL
 
 #define MODBUS_COMMAND_TIMEOUT_S 2 /* Update man pages if this changes */
@@ -72,18 +73,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MODBUS_QUANTITY_WRITE_REGISTER_MAX 123
 #define MODBUS_CONTENTS_MAX (MODBUS_QUANTITY_WRITE_REGISTER_MAX * 2)
 
-static const char *modbus_field_server            = "modbus_server";
-static const char *modbus_field_port              = "modbus_port";
-static const char *modbus_field_function          = "modbus_function_code";
-static const char *modbus_field_exception_code    = "modbus_exception_code";
-static const char *modbus_field_starting_address  = "modbus_starting_address";
-static const char *modbus_field_quantity          = "modbus_quantity";
-static const char *modbus_field_bytes             = "modbus_bytes";
-static const char *modbus_field_status            = "modbus_status";
-static const char *modbus_field_contents          = "modbus_contents";
+static const char *modbus_field_server            		= "modbus_server";
+static const char *modbus_field_port              		= "modbus_port";
+static const char *modbus_field_function          		= "modbus_function_code";
+static const char *modbus_field_exception_code    		= "modbus_exception_code";
+static const char *modbus_field_starting_address  		= "modbus_starting_address";
+static const char *modbus_field_quantity          		= "modbus_quantity";
+static const char *modbus_field_bytes             		= "modbus_bytes";
+static const char *modbus_field_status            		= "modbus_status";
+static const char *modbus_field_contents          		= "modbus_contents";
 
-static const char *modbus_field_interval_ms       = "modbus_interval_ms";
-static const char *modbus_field_response_topic    = "modbus_response_topic";
+static const char *modbus_field_interval_ms       		= "modbus_interval_ms";
+static const char *modbus_field_oneshot_timeout_ms 		= "modbus_oneshot_timeout_ms";
+static const char *modbus_field_response_topic    		= "modbus_response_topic";
+
+static const char *modbus_field_error                	= "modbus_error";
+static const char *modbus_field_error_oneshot_timeout	= "oneshot_timeout";
 
 struct modbus_data;
 
@@ -104,6 +109,7 @@ struct modbus_command_node {
 	uint64_t last_seen_time;
 	uint64_t send_time;
 	uint64_t interval_ms;
+	uint64_t oneshot_timeout_ms;
 	char *response_topic;
 	rrr_u16 response_topic_length;
 	struct modbus_command command;
@@ -120,6 +126,7 @@ struct modbus_data {
 	struct rrr_socket_client_collection *collection_tcp;
 	struct rrr_modbus_client_callbacks modbus_client_callbacks;
 	struct modbus_command_collection commands;
+	struct modbus_command_collection oneshot_commands;
 	struct rrr_event_collection events;
 	rrr_event_handle event_process;
 };
@@ -151,7 +158,8 @@ static void modbus_command_collection_destroy (struct modbus_command_collection 
 static int modbus_command_node_new (
 		struct modbus_command_node **target,
 		struct modbus_data *data,
-		struct modbus_command *command
+		struct modbus_command *command,
+		uint64_t oneshot_timeout_ms
 ) {
 	int ret = 0;
 
@@ -178,6 +186,7 @@ static int modbus_command_node_new (
 
 	node->data = data;
 	node->command = *command;
+	node->oneshot_timeout_ms = oneshot_timeout_ms;
 
 	*target = node;
 
@@ -232,6 +241,91 @@ static void modbus_command_node_update (
 	node->interval_ms = interval_ms;
 }
 
+static int modbus_command_collection_push_or_replace_polling_command (
+	struct modbus_data *data,
+	struct modbus_command *command,
+	uint64_t interval_ms,
+	char **response_topic
+) {
+	int ret = 0;
+	struct modbus_command_node *node;
+
+	RRR_LL_ITERATE_BEGIN(&data->commands, struct modbus_command_node);
+		if (memcmp(&node->command, command, sizeof(*command)) != 0) {
+			RRR_LL_ITERATE_NEXT();
+		}
+
+		RRR_DBG_2("Modbus instance %s updating command server %s:%u function 0x%02x starting address %u quantity %u interval %" PRIu64 "->%" PRIu64 " response topic '%s'\n",
+			INSTANCE_D_NAME(data->thread_data),
+			command->server,
+			command->port,
+			command->function,
+			command->starting_address,
+			command->quantity,
+			node->interval_ms,
+			interval_ms,
+			*response_topic
+		);
+
+		modbus_command_node_update(node, interval_ms, response_topic, 0 /* Not first */);
+
+		goto out;
+	RRR_LL_ITERATE_END();
+
+	RRR_DBG_2("Modbus instance %s new command server %s:%u function 0x%02x starting address %u quantity %u interval %" PRIu64 " response topic '%s'\n",
+		INSTANCE_D_NAME(data->thread_data),
+		command->server,
+		command->port,
+		command->function,
+		command->starting_address,
+		command->quantity,
+		interval_ms,
+		*response_topic
+	);
+
+	if ((ret = modbus_command_node_new (
+			&node,
+			data,
+			command,
+			0 /* Oneshot timeout */
+	)) != 0) {
+		goto out;
+	}
+
+	RRR_LL_PUSH(&data->commands, node);
+
+	modbus_command_node_update(node, interval_ms, response_topic, 1 /* First */);
+
+	out:
+	return ret;
+}
+
+static int modbus_command_collection_push_oneshot_command (
+	struct modbus_data *data,
+	struct modbus_command *command,
+	char **response_topic,
+	uint64_t oneshot_timeout_ms
+) {
+	int ret = 0;
+	struct modbus_command_node *node;
+
+	if ((ret = modbus_command_node_new (
+			&node,
+			data,
+			command,
+			oneshot_timeout_ms
+	)) != 0) {
+		goto out;
+	}
+
+	RRR_LL_PUSH(&data->oneshot_commands, node);
+
+	modbus_command_node_update(node, 0, response_topic, 1 /* First */);
+
+	out:
+	return ret;
+}
+
 static int modbus_command_collection_push_or_replace (
 		struct modbus_data *data,
 		const char *server,
@@ -242,11 +336,11 @@ static int modbus_command_collection_push_or_replace (
 		uint8_t *contents,
 		uint32_t contents_length,
 		uint64_t interval_ms,
+		uint64_t oneshot_timeout_ms,
 		char **response_topic
 ) {
 	int ret = 0;
 
-	struct modbus_command_node *node;
 	struct modbus_command command = {0};
 
 	assert(server != NULL && *server != '\0');
@@ -276,51 +370,12 @@ static int modbus_command_collection_push_or_replace (
 	if (contents != NULL && contents_length > 0) {
 		memcpy(command.contents, contents, contents_length);
 	}
-
-	RRR_LL_ITERATE_BEGIN(&data->commands, struct modbus_command_node);
-		if (memcmp(&node->command, &command, sizeof(command)) != 0) {
-			RRR_LL_ITERATE_NEXT();
-		}
-
-		RRR_DBG_2("Modbus instance %s updating command server %s:%u function 0x%02x starting address %u quantity %u interval %" PRIu64 "->%" PRIu64 " response topic '%s'\n",
-			INSTANCE_D_NAME(data->thread_data),
-			server,
-			port,
-			function,
-			starting_address,
-			quantity,
-			node->interval_ms,
-			interval_ms,
-			*response_topic
-		);
-
-		modbus_command_node_update(node, interval_ms, response_topic, 0 /* Not first */);
-
-		goto out;
-	RRR_LL_ITERATE_END();
-
-	RRR_DBG_2("Modbus instance %s new command server %s:%u function 0x%02x starting address %u quantity %u interval %" PRIu64 " response topic '%s'\n",
-		INSTANCE_D_NAME(data->thread_data),
-		server,
-		port,
-		function,
-		starting_address,
-		quantity,
-		interval_ms,
-		*response_topic
-	);
-
-	if ((ret = modbus_command_node_new (
-			&node,
-			data,
-			&command
-	)) != 0) {
-		goto out;
+	if (oneshot_timeout_ms == 0) {
+		modbus_command_collection_push_or_replace_polling_command(data, &command, interval_ms, response_topic);
 	}
-
-	RRR_LL_PUSH(&data->commands, node);
-
-	modbus_command_node_update(node, interval_ms, response_topic, 1 /* First */);
+	else {
+		modbus_command_collection_push_oneshot_command(data, &command, response_topic, oneshot_timeout_ms);
+	}
 
 	out:
 	return ret;
@@ -337,6 +392,7 @@ static void modbus_data_cleanup(struct modbus_data *data) {
 		rrr_socket_client_collection_destroy(data->collection_tcp);
 	}
 	modbus_command_collection_destroy(&data->commands);
+	modbus_command_collection_destroy(&data->oneshot_commands);
 }
 
 static int modbus_client_data_new (
@@ -524,6 +580,54 @@ static int modbus_output (
 	}
 
 	out:
+	return ret;
+}
+
+static int modbus_output_onsehot_timeout (
+		struct modbus_command_node *node
+) {
+	int ret = 0;
+
+	struct rrr_array array = {0};
+
+	if ((ret = rrr_array_push_value_str_with_tag (&array, modbus_field_error, modbus_field_error_oneshot_timeout)) != 0) {
+		RRR_MSG_0("Failed to push value in %s\n", __func__);
+		goto out;
+	}
+	if ((ret = rrr_array_push_value_str_with_tag (&array, modbus_field_server, node->command.server)) != 0) {
+		RRR_MSG_0("Failed to push value in %s\n", __func__);
+		goto out;
+	}
+	if ((ret = rrr_array_push_value_u64_with_tag (&array, modbus_field_port, node->command.port)) != 0) {
+		RRR_MSG_0("Failed to push value in %s\n", __func__);
+		goto out;
+	}
+	if ((ret = rrr_array_push_value_u64_with_tag (&array, modbus_field_function, node->command.function)) != 0) {
+		RRR_MSG_0("Failed to push value in %s\n", __func__);
+		goto out;
+	}
+
+	struct modbus_output_callback_data callback_data = {
+		&array,
+		node->response_topic,
+		node->response_topic_length
+	};
+
+	if ((ret = rrr_message_broker_write_entry (
+			INSTANCE_D_BROKER_ARGS(node->data->thread_data),
+			NULL,
+			0,
+			0,
+			NULL,
+			modbus_output_callback,
+			&callback_data,
+			INSTANCE_D_CANCEL_CHECK_ARGS(node->data->thread_data)
+	)) != 0) {
+		goto out;
+	}
+
+	out:
+	rrr_array_clear(&array);
 	return ret;
 }
 
@@ -929,6 +1033,9 @@ static int modbus_callback_data_prepare (
 	}
 
 	out:
+	if (node->oneshot_timeout_ms > 0) {
+		RRR_LL_REMOVE_NODE_IF_EXISTS(&data->oneshot_commands, struct modbus_command_node, node,  modbus_command_node_destroy(node));
+	}
 	return ret;
 
 }
@@ -1019,11 +1126,13 @@ static void modbus_event_process (evutil_socket_t fd, short flags, void *arg) {
 	(void)(fd);
 	(void)(flags);
 
-	uint64_t command_time_limit = rrr_time_get_64() - MODBUS_COMMAND_TIMEOUT_S * 1000 * 1000;
-	uint64_t send_time_limit = rrr_time_get_64() - MODBUS_COMMAND_SEND_TIMEOUT_S * 1000 * 1000;
+	uint64_t curr_time_us = rrr_time_get_64();
+	uint64_t command_time_limit = curr_time_us - MODBUS_COMMAND_TIMEOUT_S * 1000 * 1000;
+	uint64_t send_time_limit = curr_time_us - MODBUS_COMMAND_SEND_TIMEOUT_S * 1000 * 1000;
 
 	RRR_EVENT_HOOK();
 
+	/* Polling commands */
 	RRR_LL_ITERATE_BEGIN(&data->commands, struct modbus_command_node);
 		if (node->last_seen_time < command_time_limit) {
 			RRR_DBG_2("Modbus instance %s timeout for command server %s:%u function 0x%02x starting address %u quantity %u interval %" PRIu64 "\n",
@@ -1050,6 +1159,24 @@ static void modbus_event_process (evutil_socket_t fd, short flags, void *arg) {
 			RRR_LL_ITERATE_SET_DESTROY();
 		}
 	RRR_LL_ITERATE_END_CHECK_DESTROY(&data->commands, 0; modbus_command_node_destroy(node));
+
+	/* Oneshot commands */
+	RRR_LL_ITERATE_BEGIN(&data->oneshot_commands, struct modbus_command_node);
+	uint64_t timeout_us = node->oneshot_timeout_ms * 1000;
+	if (node->send_time > 0 && curr_time_us > (node->send_time + timeout_us)) {
+		RRR_MSG_0("Modbus instance %s send timeout for command server %s:%u function 0x%02x starting address %u quantity %u oneshot timeout %" PRIu64 ", server is not reachable.\n",
+			INSTANCE_D_NAME(data->thread_data),
+			node->command.server,
+			node->command.port,
+			node->command.function,
+			node->command.starting_address,
+			node->command.quantity,
+			node->oneshot_timeout_ms
+		);
+		modbus_output_onsehot_timeout(node);
+		RRR_LL_ITERATE_SET_DESTROY();
+	}
+	RRR_LL_ITERATE_END_CHECK_DESTROY(&data->oneshot_commands, 0; modbus_command_node_destroy(node));
 }
 
 #define GET_VALUE(name,type)                                                                                     \
@@ -1089,6 +1216,7 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 	uint8_t *modbus_contents = NULL;
 	uint32_t modbus_contents_length = 0;
 	unsigned long long modbus_interval_ms = MODBUS_DEFAULT_INTERVAL_MS;
+	unsigned long long modbus_oneshot_timeout_ms = MODBUS_DEFAULT_ONESHOT_TIMEOUT_MS;
 	char *modbus_response_topic = MODBUS_DEFAULT_RESPONSE_TOPIC;
 
 	RRR_DBG_2("modbus instance %s received a message with timestamp %llu\n",
@@ -1142,8 +1270,29 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 
 	GET_VALUE_ULL(starting_address);
 	GET_VALUE_ULL(quantity);
-	GET_VALUE_ULL(interval_ms);
 	GET_VALUE_STR(response_topic);
+
+	int interval_ms_present = rrr_array_has_tag(&array, modbus_field_interval_ms);
+	int oneshot_timeout_ms_present =  rrr_array_has_tag(&array, modbus_field_oneshot_timeout_ms);
+
+	if (interval_ms_present && oneshot_timeout_ms_present) {
+		RRR_MSG_0("Both modbus_interval_ms and modbus_oneshot_timeout_ms present in command message to modbus instance %s, dropping it.\n",
+			INSTANCE_D_NAME(data->thread_data));
+		ret = 0;
+		goto drop;
+	}
+	else if (interval_ms_present) {
+		GET_VALUE_ULL(interval_ms);
+	}
+	else if (oneshot_timeout_ms_present) {
+		GET_VALUE_ULL(oneshot_timeout_ms);
+		if (modbus_oneshot_timeout_ms == 0) {
+			RRR_MSG_0("Invalid value for field 'modbus_oneshot_timeout_ms' %llu to modbus instance %s, value has to be 1 or greater. Dropping it.\n",
+				modbus_oneshot_timeout_ms, INSTANCE_D_NAME(data->thread_data));
+			ret = 0;
+			goto drop;
+		}
+	}
 
 	if (modbus_function == RRR_MODBUS_FUNCTION_CODE_06_WRITE_SINGLE_REGISTER ||
 		modbus_function == RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTERS) {
@@ -1173,14 +1322,14 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 	}
 
 	if (modbus_port < 1 || modbus_port > 65535) {
-		RRR_MSG_0("Field 'modbus_port' out of range in command message to modbus instance %s. Range is %u-%u while %" PRIu64 " was given, dropping it.\n",
+		RRR_MSG_0("Field 'modbus_port' out of range in command message to modbus instance %s. Range is %d-%d while %llu was given, dropping it.\n",
 			INSTANCE_D_NAME(data->thread_data), 1, 65535, modbus_port);
 		goto drop;
 	}
 
 	if (modbus_response_topic != NULL && *modbus_response_topic != '\0') {
 		if (strlen(modbus_response_topic) > RRR_MSG_TOPIC_MAX) {
-			RRR_MSG_0("Field 'modbus_response_topic' exceeds maximum length of %u in command message to modbus instance %s, dropping it.\n",
+			RRR_MSG_0("Field 'modbus_response_topic' exceeds maximum length of %d in command message to modbus instance %s, dropping it.\n",
 				RRR_MSG_TOPIC_MAX, INSTANCE_D_NAME(data->thread_data));
 			goto drop;
 		}
@@ -1192,13 +1341,13 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 	    modbus_function != RRR_MODBUS_FUNCTION_CODE_04_READ_INPUT_REGISTERS &&
 	    modbus_function != RRR_MODBUS_FUNCTION_CODE_06_WRITE_SINGLE_REGISTER &&
 	    modbus_function != RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTERS) {
-		RRR_MSG_0("Invalid value for field 'modbus_function' %" PRIu64 " to modbus instance %s, only a value between 1 and 3 is allowed. Dropping it.\n",
+		RRR_MSG_0("Invalid value for field 'modbus_function' %llu to modbus instance %s, only a values 1, 2, 3, 4, 6 and 16 is allowed. Dropping it.\n",
 			modbus_function, INSTANCE_D_NAME(data->thread_data));
 		goto drop;
 	}
 
 	if (modbus_starting_address > MODBUS_STARTING_ADDRESS_MAX) {
-		RRR_MSG_0("Invalid value for field 'modbus_starting_address' %" PRIu64 " to modbus instance %s, maximum value is %u. Dropping it.\n",
+		RRR_MSG_0("Invalid value for field 'modbus_starting_address' %llu to modbus instance %s, maximum value is %d. Dropping it.\n",
 			modbus_starting_address, INSTANCE_D_NAME(data->thread_data), MODBUS_STARTING_ADDRESS_MAX);
 		goto drop;
 	}
@@ -1207,7 +1356,7 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 		case RRR_MODBUS_FUNCTION_CODE_01_READ_COILS:
 		case RRR_MODBUS_FUNCTION_CODE_02_READ_DISCRETE_INPUTS:
 			if (modbus_quantity < MODBUS_QUANTITY_COIL_MIN || modbus_quantity > MODBUS_QUANTITY_COIL_MAX) {
-				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %u-%u for this function (%u) while %" PRIu64 " was given, dropping it.\n",
+				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %d-%d for this function (%llu) while %llu was given, dropping it.\n",
 					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_COIL_MIN, MODBUS_QUANTITY_COIL_MAX, modbus_function, modbus_quantity);
 				goto drop;
 			}
@@ -1215,7 +1364,7 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 		case RRR_MODBUS_FUNCTION_CODE_03_READ_HOLDING_REGISTERS:
 		case RRR_MODBUS_FUNCTION_CODE_04_READ_INPUT_REGISTERS:
 			if (modbus_quantity < MODBUS_QUANTITY_READ_REGISTER_MIN || modbus_quantity > MODBUS_QUANTITY_READ_REGISTER_MAX) {
-				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %u-%u for this function (%u) while %" PRIu64 " was given, dropping it.\n",
+				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %d-%d for this function (%llu) while %llu was given, dropping it.\n",
 					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_READ_REGISTER_MIN, MODBUS_QUANTITY_READ_REGISTER_MAX, modbus_function, modbus_quantity);
 				goto drop;
 			}
@@ -1229,13 +1378,13 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 			break;
 		case RRR_MODBUS_FUNCTION_CODE_16_WRITE_MULTIPLE_REGISTERS:
 			if (modbus_quantity < MODBUS_QUANTITY_WRITE_REGISTER_MIN || modbus_quantity > MODBUS_QUANTITY_WRITE_REGISTER_MAX) {
-				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %u-%u for this function (%u) while %" PRIu64 " was given, dropping it.\n",
+				RRR_MSG_0("Field 'modbus_quantity' out of range in command message to modbus instance %s. Range is %d-%d for this function (%llu) while %llu was given, dropping it.\n",
 					INSTANCE_D_NAME(data->thread_data), MODBUS_QUANTITY_WRITE_REGISTER_MIN, MODBUS_QUANTITY_WRITE_REGISTER_MAX, modbus_function, modbus_quantity);
 				goto drop;
 			}
 
 			if (modbus_contents_length != modbus_quantity * 2) {
-				RRR_MSG_0("Invalid size for field 'modbus_content' to modbus instance %s for function code 0x10. Size should be 'modbus_quantity'*2 (%u) while %" PRIu32 " was given, dropping it.\n",
+				RRR_MSG_0("Invalid size for field 'modbus_content' to modbus instance %s for function code 0x10. Size should be 'modbus_quantity'*2 (%llu) while %" PRIu32 " was given, dropping it.\n",
 					INSTANCE_D_NAME(data->thread_data), modbus_quantity*2u, modbus_contents_length);
 				goto drop;
 			}
@@ -1256,6 +1405,7 @@ static int modbus_poll_callback (RRR_MODULE_POLL_CALLBACK_SIGNATURE) {
 			modbus_contents,
 			modbus_contents_length,
 			(uint64_t) modbus_interval_ms,
+			(uint64_t) modbus_oneshot_timeout_ms,
 			&modbus_response_topic /* Memory is consumed upon success */
 	)) != 0) {
 		goto drop;


### PR DESCRIPTION
I added functionality for a "oneshot" modbus command that always sends one modbus requests instead of polling with an interval.
To trigger a oneshot command one should pass the option **`modbus_oneshot_timeout_ms`**.

If a timeout happens the module now returns a response with tag **`modbus_error`** and string value **`oneshot_timeout`**. I feel that maybe there is a better way to name these fields, what do you think?

- Added new functionality for oneshot command in`p_modbus.c`
- Fixed some incorrect printf format strings in `modbus_poll_callback`
- Updated man page